### PR TITLE
Dyntest allure report Changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,15 +117,23 @@
             <artifactId>curator-x-discovery</artifactId>
             <version>${curator.version}</version>
         </dependency>
-        <!--
         <dependency>
             <groupId>io.qameta.allure</groupId>
             <artifactId>allure-junit5</artifactId>
             <version>2.13.6</version>
             <scope>test</scope>
         </dependency>
-        -->
-
+        <dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-commons</artifactId>
+			<version>1.7.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-engine</artifactId>
+			<version>1.7.0</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
     <build>
         <plugins>
@@ -283,11 +291,34 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
+                <configuration>
+					<useSystemClassLoader>true</useSystemClassLoader>
+					<testFailureIgnore>true</testFailureIgnore>
+					<argLine>
+						-javaagent:"${settings.localRepository}/org/aspectj/aspectjweaver/1.8.10/aspectjweaver-1.8.10.jar"
+					</argLine>
+					<systemProperties>
+						<property>
+							<name>allure.results.directory</name>
+							<value>target/allure-results</value>
+						</property>
+					</systemProperties>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.aspectj</groupId>
+						<artifactId>aspectjweaver</artifactId>
+						<version>1.8.10</version>
+					</dependency>
+				</dependencies>
             </plugin>
             <plugin>
                 <groupId>io.qameta.allure</groupId>
                 <artifactId>allure-maven</artifactId>
-                <version>2.8</version>
+                <version>2.10.0</version>
+                <configuration>
+					<reportVersion>2.4.1</reportVersion>
+				</configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/iudx/catalogue/server/apiserver/IntegrationTest.java
+++ b/src/test/java/iudx/catalogue/server/apiserver/IntegrationTest.java
@@ -86,7 +86,7 @@ public class IntegrationTest {
   private static final Logger LOGGER = LogManager.getLogger(IntegrationTest.class);
   private static String HOST = "";
   private static int PORT;
-  private static final String BASE_URL = "http://127.0.0.1:8080/iudx/cat/v1/";
+  private static final String BASE_URL = "http://127.0.0.1:8443/iudx/cat/v1/";
   private String URL = "";
 
   /** Token for crud apis */


### PR DESCRIPTION
Notes:

- mvn clean test allure:serve (Starts a web-server to host the allure report after test execution)
- mvn clean test -> mvn allure:serve 
- For Generating html report after test:   mvn allure:report  (report will be generated in target\site\allure-maven-plugin)
- By default allure requires a web server to open the test-reports, for opening the reports without a web-server disables same origin policy in chrome (not recommended)