### PR TITLE
Junit fix, removing manual dependencies

### DIFF
--- a/src/test/java/iudx/catalogue/server/apiserver/ApiServerVerticlePreprareTest.java
+++ b/src/test/java/iudx/catalogue/server/apiserver/ApiServerVerticlePreprareTest.java
@@ -1,0 +1,181 @@
+package iudx.catalogue.server.apiserver;
+
+import static iudx.catalogue.server.apiserver.util.Constants.HEADER_CONTENT_TYPE;
+import static iudx.catalogue.server.apiserver.util.Constants.HEADER_TOKEN;
+import static iudx.catalogue.server.apiserver.util.Constants.MIME_APPLICATION_JSON;
+import static iudx.catalogue.server.util.Constants.KEYSTORE_PASSWORD;
+import static iudx.catalogue.server.util.Constants.KEYSTORE_PATH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.JksOptions;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.reactivex.core.Vertx;
+import io.vertx.reactivex.core.file.FileSystem;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import iudx.catalogue.server.Configuration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import java.util.Iterator;
+
+/**
+ * 
+ * Tests & onboard resourceServer, provide and resourceGroup items.
+ *
+ */
+@ExtendWith(VertxExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ApiServerVerticlePreprareTest {
+
+  /* LOGGER instance */
+  private static final Logger LOGGER = LogManager.getLogger(ApiServerVerticlePreprareTest.class);
+  private static String HOST = "";
+  private static int PORT;
+  private static final String BASE_URL = "/iudx/cat/v1/";
+
+  /** Token for crud apis */
+  private static String TOKEN = "";
+  private static String ADMIN_TOKEN = "";
+
+  private static WebClient client;
+  private static FileSystem fileSystem;
+  
+  @BeforeAll
+  static void startVertx(VertxTestContext testContext, Vertx vertx) throws InterruptedException {
+
+    fileSystem = vertx.fileSystem();
+
+    /* configuration setup */
+    JsonObject apiVerticleConfig = Configuration.getConfiguration("./configs/config-test.json", 3);
+
+    String keyStore = apiVerticleConfig.getString(KEYSTORE_PATH);
+    String keyStorePassword = apiVerticleConfig.getString(KEYSTORE_PASSWORD);
+    HOST = apiVerticleConfig.getString("ip");
+    PORT = apiVerticleConfig.getInteger("port");
+    TOKEN = apiVerticleConfig.getString(HEADER_TOKEN);
+    ADMIN_TOKEN = apiVerticleConfig.getString("admin_token");
+    
+
+    /* Options for the web client connections */
+    JksOptions options = new JksOptions().setPath(keyStore).setPassword(keyStorePassword);
+
+    WebClientOptions clientOptions = new WebClientOptions()
+                                            .setSsl(true)
+                                            .setVerifyHost(false)
+                                            .setTrustAll(true)
+                                            .setTrustStoreOptions(options);
+    client = WebClient.create(vertx, clientOptions);
+
+    testContext.completeNow();
+  }
+
+  /**
+   * Creates the resourceServer and provider items.
+   * 
+   * @param testContext
+   * @throws InterruptedException
+   */
+  @Test
+  @Order(1)
+  @DisplayName("Preprare onboarder items[Status:201, Endpoint: /item]")
+  public void createResSvrPvrdItem(VertxTestContext testContext) throws InterruptedException {
+
+    var wrapper = new Object() {
+      int count = 0;
+    };
+
+    fileSystem.readFile("src/test/resources/resourceSvrProvider.json", fileRes -> {
+      if (fileRes.succeeded()) {
+
+        JsonArray resources = fileRes.result().toJsonArray();
+        int numItems = resources.size();
+        LOGGER.info("Total items = " + String.valueOf(resources.size()));
+        Iterator<Object> objectIterator = resources.iterator();
+
+
+        while (objectIterator.hasNext()) {
+          // Send the file to the server using POST
+          client.post(PORT, HOST, BASE_URL.concat("item")).putHeader(HEADER_TOKEN, TOKEN)
+              .putHeader(HEADER_CONTENT_TYPE, MIME_APPLICATION_JSON)
+              // .putHeader("instance", "pune")
+              .sendJson(objectIterator.next(), serverResponse -> {
+                if (serverResponse.succeeded()) {
+                  if (serverResponse.result().statusCode() == 201) {
+                    wrapper.count++;
+                    testContext.completeNow();
+                  }
+                  if (wrapper.count == numItems - 1) {
+                    testContext.completeNow();
+                  }
+                  assertEquals(201, serverResponse.result().statusCode());
+                } else if (serverResponse.failed()) {
+                  testContext.failed();
+                }
+              });
+        }
+      } else if (fileRes.failed()) {
+        LOGGER.error("Problem in reading test data file: ".concat(fileRes.cause().toString()));
+      }
+    });
+  }
+
+  /**
+   * creates the resourceGroup item.
+   * 
+   * @param testContext
+   * @throws InterruptedException
+   */
+  @Test
+  @Order(2)
+  @DisplayName("Preprare onboarder items[Status:201, Endpoint: /item]")
+  public void createResourceGrpItem(VertxTestContext testContext) throws InterruptedException {
+
+    Thread.sleep(5000);
+    var wrapper = new Object() {
+      int count = 0;
+    };
+
+    fileSystem.readFile("src/test/resources/resourceGroup.json", fileRes -> {
+      if (fileRes.succeeded()) {
+
+        JsonArray resources = fileRes.result().toJsonArray();
+        int numItems = resources.size();
+        LOGGER.info("Total items = " + String.valueOf(resources.size()));
+        Iterator<Object> objectIterator = resources.iterator();
+
+
+        while (objectIterator.hasNext()) {
+          // Send the file to the server using POST
+          client.post(PORT, HOST, BASE_URL.concat("item")).putHeader(HEADER_TOKEN, TOKEN)
+              .putHeader(HEADER_CONTENT_TYPE, MIME_APPLICATION_JSON)
+              // .putHeader("instance", "pune")
+              .sendJson(objectIterator.next(), serverResponse -> {
+                if (serverResponse.succeeded()) {
+                  if (serverResponse.result().statusCode() == 201) {
+                    wrapper.count++;
+                    testContext.completeNow();
+                  }
+                  if (wrapper.count == numItems - 1) {
+                    testContext.completeNow();
+                  }
+                  assertEquals(201, serverResponse.result().statusCode());
+                } else if (serverResponse.failed()) {
+                  testContext.failed();
+                }
+              });
+        }
+      } else if (fileRes.failed()) {
+        LOGGER.error("Problem in reading test data file: ".concat(fileRes.cause().toString()));
+      }
+    });
+  }
+}

--- a/src/test/resources/prepareDeleteItems.json
+++ b/src/test/resources/prepareDeleteItems.json
@@ -1,0 +1,11 @@
+[
+	{
+		"id": "datakaveri.org/f7e044eee8122b5c87dce6e7ad64f3266afa41dc/rs.iudx.io"
+	},
+	{
+		"id": "datakaveri.org/f7e044eee8122b5c87dce6e7ad64f3266afa41dc"
+	},
+	{
+		"id": "datakaveri.org/f7e044eee8122b5c87dce6e7ad64f3266afa41dc/rs.iudx.io/aqm-bosch-climo"
+	}
+]

--- a/src/test/resources/resourceGroup.json
+++ b/src/test/resources/resourceGroup.json
@@ -1,153 +1,191 @@
-{
-    "@context": "https://voc.iudx.org.in/",
-    "type": ["iudx:ResourceGroup", "iudx:EnvAQM"],
-    "description": "Bosch Climo Air quality monitoring resources",
-    "name": "aqm-bosch-climo",
-    "tags": [
-        "environment",
-        "air quality",
-        "climate",
-        "air",
-        "aqi",
-        "aqm",
-        "climo",
-        "pollution",
-        "so2",
-        "co2",
-        "co",
-        "no",
-        "no2",
-        "pm2.5",
-        "pm10",
-        "humidity",
-        "temperature",
-        "ozone",
-        "o3",
-        "noise",
-        "light",
-        "uv"
-    ],
-    "itemStatus": "ACTIVE",
-    "provider": "datakaveri.org/f7e044eee8122b5c87dce6e7ad64f3266afa41dc",
-    "resourceServer": "datakaveri.org/f7e044eee8122b5c87dce6e7ad64f3266afa41dc/rs.iudx.io",
-    "resourceAuthControlLevel": "OPEN",
-    "resourceType": "messageStream",
-    "authServerInfo": {
-        "type": ["AuthServerInfoValue"],
-        "authServerURL": "https://auth.iudx.org.in",
-        "authType": "iudx-auth"
-    },
-    "accessObjectInfo": {
-        "type": ["AccessObjectInfoValue"],
-        "accessObject": "https://example.com/sensorsApis.json",
-        "additionalInfoURL": "https://example.com/sensorsApis",
-        "accessObjectType": "openAPI"
-    },
-    "iudxResourceAPIs": ["attribute", "temporal"],
-    "itemCreatedAt": "2019-02-20T10:30:06.093121",
-    "location": {
-        "type": "Place",
-        "address": "Bangalore"
-    },
-    "dataDescriptor": {
-        "atmosphericPressure": {
-            "type": ["ValueDescriptor"],
-            "description": "Measured Air pressure",
-            "unitCode": "qudt:MILLIBAR",
-            "unitText": "Milli Bar",
-            "dataSchema": "iudx:Number"
-        },
-        "airQualityIndex": {
-            "type": ["ValueDescriptor"],
-            "description": "Overall AQI ",
-            "unitCode": "C62",
-            "unitText": "dimensionless",
-            "dataSchema": "iudx:Number"
-        },
-        "aqiMajorPollutant": {
-            "type": ["ValueDescriptor"],
-            "description": "Major pollutant in the AQI index.",
-            "dataSchema": "iudx:Text"
-        },
-        "co": {
-            "type": ["TimeSeriesAggregation"],
-            "description": "Describes instantaneous and/or aggregated values for carbon monooxide(CO). TimeSeriesAggregations of CO are derived over the last 24 hours",
-            "avgOverTime": {
-                "type": ["ValueDescriptor"],
-                "description": "Average value of CO for the last 24 hours",
-                "dataSchema": "iudx:Number",
-                "aggregationDuration": 24,
-                "unitCode": "X59",
-                "unitText": "part per million (ppm)"
-            },
-            "maxOverTime": {
-                "type": ["ValueDescriptor"],
-                "description": "Maximum value of CO for the last 24 hours",
-                "dataSchema": "iudx:Number",
-                "aggregationDuration": 24,
-                "unitCode": "X59",
-                "unitText": "part per million (ppm)"
-            },
-            "minOverTime": {
-                "type": ["ValueDescriptor"],
-                "description": "Maximum value of CO for the last 24 hours",
-                "dataSchema": "iudx:Number",
-                "aggregationDuration": 24,
-                "unitCode": "X59",
-                "unitText": "part per million (ppm)"
-            }
-        },
-        "pm2p5": {
-            "type": ["TimeSeriesAggregation"],
-            "description": "Describes instantaneous and/or aggregated values for PM2.5. TimeSeriesAggregations of PM2.5 are derived over the last 24 hours",
-            "instValue": {
-                "type": ["ValueDescriptor"],
-                "description": "Instantaneous value of pollutant PM2p5.",
-                "dataSchema": "iudx:Number",
-                "unitCode": "XGQ",
-                "unitText": "micro gram per cubic metre (ug/m3)",
-                "resolution": {
-                    "value": 0.1,
-                    "unitCode": "XGQ"
-                }
-            },
-            "avgOverTime": {
-                "type": ["ValueDescriptor"],
-                "description": "Average value of PM2.5 for the last 24 hours",
-                "dataSchema": "iudx:Number",
-                "aggregationDuration": 24,
-                "unitCode": "XGQ",
-                "unitText": "micro gram per cubic metre (ug/m3)"
-            }
-        },
-        "co2": {
-            "type": ["TimeSeriesAggregation"],
-            "description": "Describes instantaneous and/or aggregated values for CO2. TimeSeriesAggregations of CO2 are derived over the last 24 hours",
-            "avgOverTime": {
-                "type": ["ValueDescriptor"],
-                "description": "Average value of CO2 for the last 24 hours",
-                "dataSchema": "iudx:Number",
-                "aggregationDuration": 24,
-                "unitCode": "X59",
-                "unitText": "part per million (ppm)"
-            }
-        },
-        "pm10": {
-            "type": ["ValueDescriptor"],
-            "description": "Instantaneous value of pollutant PM10.",
-            "dataSchema": "iudx:Number",
-            "unitCode": "XGQ",
-            "unitText": "micro gram per cubic metre (ug/m3)",
-            "resolution": {
-                "value": 0.5,
-                "unitCode": "XGQ"
-            },
-            "measAccuracy": {
-                "minValue": -10,
-                "maxValue": 10, 
-                "unitCode": "qudt:Percent",
-                "unitText": "Percent"
-            }
-        }
-    }
-}
+[
+	{
+		"@context": "https://voc.iudx.org.in/",
+		"type": [
+			"iudx:ResourceGroup",
+			"iudx:EnvAQM"
+		],
+		"description": "Bosch Climo Air quality monitoring resources",
+		"name": "aqm-bosch-climo",
+		"tags": [
+			"environment",
+			"air quality",
+			"climate",
+			"air",
+			"aqi",
+			"aqm",
+			"climo",
+			"pollution",
+			"so2",
+			"co2",
+			"co",
+			"no",
+			"no2",
+			"pm2.5",
+			"pm10",
+			"humidity",
+			"temperature",
+			"ozone",
+			"o3",
+			"noise",
+			"light",
+			"uv"
+		],
+		"itemStatus": "ACTIVE",
+		"provider": "datakaveri.org/f7e044eee8122b5c87dce6e7ad64f3266afa41dc",
+		"resourceServer": "datakaveri.org/f7e044eee8122b5c87dce6e7ad64f3266afa41dc/rs.iudx.io",
+		"resourceAuthControlLevel": "OPEN",
+		"resourceType": "messageStream",
+		"authServerInfo": {
+			"type": [
+				"AuthServerInfoValue"
+			],
+			"authServerURL": "https://auth.iudx.org.in",
+			"authType": "iudx-auth"
+		},
+		"accessObjectInfo": {
+			"type": [
+				"AccessObjectInfoValue"
+			],
+			"accessObject": "https://example.com/sensorsApis.json",
+			"additionalInfoURL": "https://example.com/sensorsApis",
+			"accessObjectType": "openAPI"
+		},
+		"iudxResourceAPIs": [
+			"attribute",
+			"temporal"
+		],
+		"itemCreatedAt": "2019-02-20T10:30:06.093121",
+		"location": {
+			"type": "Place",
+			"address": "Bangalore"
+		},
+		"dataDescriptor": {
+			"atmosphericPressure": {
+				"type": [
+					"ValueDescriptor"
+				],
+				"description": "Measured Air pressure",
+				"unitCode": "qudt:MILLIBAR",
+				"unitText": "Milli Bar",
+				"dataSchema": "iudx:Number"
+			},
+			"airQualityIndex": {
+				"type": [
+					"ValueDescriptor"
+				],
+				"description": "Overall AQI ",
+				"unitCode": "C62",
+				"unitText": "dimensionless",
+				"dataSchema": "iudx:Number"
+			},
+			"aqiMajorPollutant": {
+				"type": [
+					"ValueDescriptor"
+				],
+				"description": "Major pollutant in the AQI index.",
+				"dataSchema": "iudx:Text"
+			},
+			"co": {
+				"type": [
+					"TimeSeriesAggregation"
+				],
+				"description": "Describes instantaneous and/or aggregated values for carbon monooxide(CO). TimeSeriesAggregations of CO are derived over the last 24 hours",
+				"avgOverTime": {
+					"type": [
+						"ValueDescriptor"
+					],
+					"description": "Average value of CO for the last 24 hours",
+					"dataSchema": "iudx:Number",
+					"aggregationDuration": 24,
+					"unitCode": "X59",
+					"unitText": "part per million (ppm)"
+				},
+				"maxOverTime": {
+					"type": [
+						"ValueDescriptor"
+					],
+					"description": "Maximum value of CO for the last 24 hours",
+					"dataSchema": "iudx:Number",
+					"aggregationDuration": 24,
+					"unitCode": "X59",
+					"unitText": "part per million (ppm)"
+				},
+				"minOverTime": {
+					"type": [
+						"ValueDescriptor"
+					],
+					"description": "Maximum value of CO for the last 24 hours",
+					"dataSchema": "iudx:Number",
+					"aggregationDuration": 24,
+					"unitCode": "X59",
+					"unitText": "part per million (ppm)"
+				}
+			},
+			"pm2p5": {
+				"type": [
+					"TimeSeriesAggregation"
+				],
+				"description": "Describes instantaneous and/or aggregated values for PM2.5. TimeSeriesAggregations of PM2.5 are derived over the last 24 hours",
+				"instValue": {
+					"type": [
+						"ValueDescriptor"
+					],
+					"description": "Instantaneous value of pollutant PM2p5.",
+					"dataSchema": "iudx:Number",
+					"unitCode": "XGQ",
+					"unitText": "micro gram per cubic metre (ug/m3)",
+					"resolution": {
+						"value": 0.1,
+						"unitCode": "XGQ"
+					}
+				},
+				"avgOverTime": {
+					"type": [
+						"ValueDescriptor"
+					],
+					"description": "Average value of PM2.5 for the last 24 hours",
+					"dataSchema": "iudx:Number",
+					"aggregationDuration": 24,
+					"unitCode": "XGQ",
+					"unitText": "micro gram per cubic metre (ug/m3)"
+				}
+			},
+			"co2": {
+				"type": [
+					"TimeSeriesAggregation"
+				],
+				"description": "Describes instantaneous and/or aggregated values for CO2. TimeSeriesAggregations of CO2 are derived over the last 24 hours",
+				"avgOverTime": {
+					"type": [
+						"ValueDescriptor"
+					],
+					"description": "Average value of CO2 for the last 24 hours",
+					"dataSchema": "iudx:Number",
+					"aggregationDuration": 24,
+					"unitCode": "X59",
+					"unitText": "part per million (ppm)"
+				}
+			},
+			"pm10": {
+				"type": [
+					"ValueDescriptor"
+				],
+				"description": "Instantaneous value of pollutant PM10.",
+				"dataSchema": "iudx:Number",
+				"unitCode": "XGQ",
+				"unitText": "micro gram per cubic metre (ug/m3)",
+				"resolution": {
+					"value": 0.5,
+					"unitCode": "XGQ"
+				},
+				"measAccuracy": {
+					"minValue": -10,
+					"maxValue": 10,
+					"unitCode": "qudt:Percent",
+					"unitText": "Percent"
+				}
+			}
+		}
+	}
+]

--- a/src/test/resources/resourceSvrProvider.json
+++ b/src/test/resources/resourceSvrProvider.json
@@ -1,0 +1,71 @@
+[
+    {
+        "@context": "https://voc.iudx.org.in/",
+        "type": [
+            "iudx:ResourceServer"
+        ],
+        "id": "datakaveri.org/f7e044eee8122b5c87dce6e7ad64f3266afa41dc/rs.iudx.io",
+        "provider": "datakaveri.org/f7e044eee8122b5c87dce6e7ad64f3266afa41dc",
+        "name": "iudxResourceServer",
+        "description": "Generic IUDX resource server",
+        "tags": [
+            "IUDX, Resource, Server, Platform"
+        ],
+        "resourceServerHTTPAccessURL": "rs.iudx.io",
+        "itemStatus": "ACTIVE",
+        "itemCreatedAt": "2020-07-01T10:03:26+0000",
+        "resourceServerOrg": {
+            "name": "iudx",
+            "additionalInfoURL": "https://iudx.org.in",
+            "location": {
+                "type": "Place",
+                "address": "IISc, Bangalore",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                        75.92,
+                        13.5
+                    ]
+                }
+            }
+        },
+        "location": {
+            "type": "Place",
+            "address": "Pune",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    74.92,
+                    12.5
+                ]
+            }
+        }
+    },
+    {
+        "@context": "https://voc.iudx.org.in/",
+        "type": [
+            "iudx:Provider"
+        ],
+        "id": "datakaveri.org/f7e044eee8122b5c87dce6e7ad64f3266afa41dc",
+        "name": "IUDXAdmin",
+        "description": "Administrator of the IUDX platform",
+        "tags": [
+            "IUDX, Admin, Platform"
+        ],
+        "providerOrg": {
+            "name": "iudx",
+            "additionalInfoURL": "https://iudx.org.in",
+            "location": {
+                "type": "Place",
+                "address": "ABD area, Pune",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                        79.92,
+                        15.5
+                    ]
+                }
+            }
+        }
+    }
+]


### PR DESCRIPTION
Manual dependencies has been removed, the order of the test class executions are:
`ApiServerVerticlePreprareTest -> ApiServerVerticleTest -> DatabaseServiceTest -> ServerVerticleDeboardTest`