### PR TITLE
Logging configurable level and format

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ networks:
 services:
 
   prod:
-    image: iudx/cat-depl:latest
+    image: iudx/cat-prod:latest
     environment:
       - HOSTNAME=server
       - ZOOKEEPER=zookeeper

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
       - ./docs/:/usr/share/app/docs
       - ./configs/keystore.jks:/usr/share/app/configs/keystore.jks
       - ./ui/dist/:/usr/share/app/ui/dist
-      - /tmp/iudx/:/tmp/iudx/
-      
     depends_on:
       - "zookeeper"
     ports:
@@ -44,7 +42,6 @@ services:
       - ./configs/config-dev.json:/usr/share/app/configs/config.json
       - ./configs/keystore.jks:/usr/share/app/configs/keystore.jks
       - ./ui/dist/:/usr/share/app/ui/dist
-      - /tmp/iudx/:/tmp/iudx/
     ports:
       - "8080:8080"
       - "9000:9000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,14 @@ services:
       - HOSTNAME=server
       - ZOOKEEPER=zookeeper
       - CAT_URL=https://catalogue.iudx.org.in
+      - LOG_LEVEL=INFO
     volumes:
       - ./configs/config-depl.json:/usr/share/app/configs/config.json
       - ./docs/:/usr/share/app/docs
       - ./configs/keystore.jks:/usr/share/app/configs/keystore.jks
       - ./ui/dist/:/usr/share/app/ui/dist
       - /tmp/iudx/:/tmp/iudx/
+      
     depends_on:
       - "zookeeper"
     ports:
@@ -37,6 +39,7 @@ services:
     image: iudx/cat-dev:latest
     environment:
       - CAT_URL=https://catalogue.iudx.org.in
+      - LOG_LEVEL=DEBUG
     volumes:
       - ./configs/config-dev.json:/usr/share/app/configs/config.json
       - ./configs/keystore.jks:/usr/share/app/configs/keystore.jks
@@ -60,10 +63,12 @@ services:
     image: iudx/cat-test:latest
     environment:
       - CAT_URL=https://catalogue.iudx.org.in
+      - LOG_LEVEL=INFO
     volumes:
       - ./src/:/usr/share/app/src
       - ./configs/config-test.json:/usr/share/app/configs/config-test.json
       - /tmp/test:/tmp/test
+      
     command: bash -c "mvn clean test -Dtest=IntegrationTest && cp -r target /tmp/test"
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,16 @@
             <version>2.2.12</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>2.13.3</version>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -24,7 +24,7 @@
 		</RollingFile>
     </Appenders>
     <Loggers>
-        <logger name="iudx.catalogue.server" level="ALL"
+        <logger name="iudx.catalogue.server" level="${env:LOG_LEVEL}"
             additivity="false">
             <appender-ref ref="ConsoleAppender" />
 			<appender-ref ref="RollingFile" />

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -3,7 +3,7 @@
     <Properties>
         <Property name="LOG_EXCEPTION_CONVERSION_WORD">%xEx</Property>
         <Property name="LOG_LEVEL_PATTERN">%p</Property>
-        <Property name="CONSOLE_LOG_PATTERN">time=%d{YYYY-MM-dd'T'HH:mm:ssZ} level=${LOG_LEVEL_PATTERN} loggerName=%c message="%m" source=cat sourceUrl=$${env:CAT_URL} exception="%xThrowable{separator(|)}"%n</Property>
+	<Property name="CONSOLE_LOG_PATTERN">time=%d{YYYY-MM-dd'T'HH:mm:ssZ} level="%highlight{${LOG_LEVEL_PATTERN}}" loggerName=%c message="%m" source=cat sourceUrl=$${env:CAT_URL} exception="%xThrowable{separator(|)}"%n</Property>
         <!-- <Property name="FILE_LOG_PATTERN">[%d{MM-dd HH:mm:ss}][${LOG_LEVEL_PATTERN}][%c]:%m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property> -->
     </Properties>
     <Appenders>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -3,14 +3,14 @@
     <Properties>
         <Property name="LOG_EXCEPTION_CONVERSION_WORD">%xEx</Property>
         <Property name="LOG_LEVEL_PATTERN">%p</Property>
-        <Property name="CONSOLE_LOG_PATTERN">[%style{%d{MM-dd HH:mm:ss}}][%highlight{${LOG_LEVEL_PATTERN}}][%c]%style{:}{faint}%m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
-        <Property name="FILE_LOG_PATTERN">[%d{MM-dd HH:mm:ss}][${LOG_LEVEL_PATTERN}][%c]:%m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
+        <Property name="CONSOLE_LOG_PATTERN">time=%d{YYYY-MM-dd'T'HH:mm:ssZ} level=${LOG_LEVEL_PATTERN} loggerName=%c message="%m" source=cat sourceUrl=$${env:CAT_URL} exception="%xThrowable{separator(|)}"%n</Property>
+        <!-- <Property name="FILE_LOG_PATTERN">[%d{MM-dd HH:mm:ss}][${LOG_LEVEL_PATTERN}][%c]:%m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property> -->
     </Properties>
     <Appenders>
         <Console name="ConsoleAppender" target="SYSTEM_OUT" follow="true">
             <PatternLayout pattern="${CONSOLE_LOG_PATTERN}" />
         </Console>
-		<RollingFile name="RollingFile" append="false" ignoreExceptions="false">
+		<!-- <RollingFile name="RollingFile" append="false" ignoreExceptions="false">
             <FileName>/tmp/iudx/cat.log</FileName>
             <FilePattern>/tmp/iudx/cat.log</FilePattern>
             <JSONLayout compact="true" eventEol="true" stacktraceAsString="true" includeTimeMillis="true">
@@ -21,13 +21,13 @@
 				<SizeBasedTriggeringPolicy size="10 MB"/>
 			</Policies>
 			<DefaultRolloverStrategy max="1" />
-		</RollingFile>
+		</RollingFile> -->
     </Appenders>
     <Loggers>
         <logger name="iudx.catalogue.server" level="${env:LOG_LEVEL}"
             additivity="false">
             <appender-ref ref="ConsoleAppender" />
-			<appender-ref ref="RollingFile" />
+			<!-- <appender-ref ref="RollingFile" /> -->
         </logger>
         <logger name="com.hazelcast" level="ERROR" additivity="false">
             <appender-ref ref="ConsoleAppender" />
@@ -35,5 +35,8 @@
         <logger name="io.netty" level="ERROR" additivity="false">
             <appender-ref ref="ConsoleAppender" />
         </logger>
+        <Root level="ERROR">
+            <appender-ref ref="ConsoleAppender"/>
+        </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Preview of [logfmt (key-value pair)](https://brandur.org/logfmt) format.
![Screenshot from 2020-12-01 14-19-11](https://user-images.githubusercontent.com/29863835/100717755-81e6a780-33e0-11eb-9797-42c86299eab9.png)

- Logfmt has advantage of readability and parsability (supported by Loki v2).
-  Time field has ISO format time value 
- Exception is nothing but  exception stack trace, its configured to output in one line separated by '|' . This is made one line coz Loki doesn't support multi-line logs for a log event [yet](https://github.com/grafana/loki/issues/74). 

Note: **Have also removed logging to file and  have only console logging.**