### PR TITLE
items name validation specialChar

### DIFF
--- a/src/main/resources/iudx/catalogue/server/validator/providerItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/providerItemSchema.json
@@ -101,7 +101,8 @@
             "default": "",
             "examples": [
                 "<provider-name>"
-            ]
+            ],
+            "pattern" : "^[a-zA-Z0-9]+(\\-*\\_*[a-zA-Z0-9]+)*$"
         },
         "description": {
             "$id": "#/properties/description",

--- a/src/main/resources/iudx/catalogue/server/validator/resourceGroupItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/resourceGroupItemSchema.json
@@ -93,7 +93,8 @@
             "default": "",
             "examples": [
                 "sensors"
-            ]
+            ],
+            "pattern" : "^[a-zA-Z0-9]+(\\-*\\_*[a-zA-Z0-9]+)*$"
         },
         "tags": {
             "$id": "#/properties/tags",

--- a/src/main/resources/iudx/catalogue/server/validator/resourceItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/resourceItemSchema.json
@@ -29,7 +29,8 @@
             "examples": [
                 "SomePlace"
             ],
-            "maxLength": 512
+            "maxLength": 512,
+            "pattern" : "^[a-zA-Z0-9]+(\\-*\\_*[a-zA-Z0-9]+)*$"
         },
         "provider": {
             "$id": "#/properties/provider",

--- a/src/main/resources/iudx/catalogue/server/validator/resourceServerItemSchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/resourceServerItemSchema.json
@@ -131,7 +131,8 @@
             "default": "",
             "examples": [
                 "IudxResourceServer"
-            ]
+            ],
+            "pattern" : "^[a-zA-Z0-9]+(\\-*\\_*[a-zA-Z0-9]+)*$"
         },
         "description": {
             "$id": "#/properties/description",


### PR DESCRIPTION
1. The name attribute of onboard items will contains Alphanumeric, hyphen (-) and underscore (_) only.
2.  The value of name will only starts and ends with Alphanumeric. Hyphen or underscore not allowed at starting or ending.