### PR TITLE
Provision for default log level

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -24,7 +24,7 @@
 		</RollingFile> -->
     </Appenders>
     <Loggers>
-        <logger name="iudx.catalogue.server" level="${env:LOG_LEVEL}"
+        <logger name="iudx.catalogue.server" level="${env:LOG_LEVEL:-DEBUG}"
             additivity="false">
             <appender-ref ref="ConsoleAppender" />
 			<!-- <appender-ref ref="RollingFile" /> -->


### PR DESCRIPTION
If environment variables not set/exported, it uses DEBUG as default LOG_LEVEL.