### PR TITLE
Adding default apiserver ports

### DIFF
--- a/configs/config-example.json
+++ b/configs/config-example.json
@@ -38,7 +38,9 @@
             "id": "iudx.catalogue.server.apiserver.ApiServerVerticle",
             "host": "catalogue.iudx.io",
             "ssl": false,
-            "port": 8080,
+            "httpPort": 8080,
+	    "keystore": "configs/keystore.jks",
+	    "keystorePassword": "password",
             "ip": "127.0.0.1",
             "catAdmin": "datakaveri.org/h7e844e2e832398d238928abcd64f3266afa41dc",
             "verticleInstances": 2
@@ -55,6 +57,17 @@
             "nlpServiceUrl": "es-vectorised-search_web_1",
             "nlpServicePort": 5000,
             "verticleInstances":2
-        }
+        },
+	    {
+            "id": "iudx.catalogue.server.auditing.AuditingVerticle",
+            "verticleInstances": 1,
+            "auditingDatabaseIP": "",
+            "auditingDatabasePort": 5432,
+            "auditingDatabaseName": "defaultdb",
+            "auditingDatabaseUserName": "immudb",
+            "auditingDatabasePassword": "password",
+            "auditingPoolSize": 25
+            }
+
     ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     depends_on:
       - "zookeeper"
     ports:
-      - "8443:8443"
+      - "8080:8080"
       - "9000:9000"
     restart: on-failure
     networks: 

--- a/src/main/java/iudx/catalogue/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/ApiServerVerticle.java
@@ -48,6 +48,8 @@ public class ApiServerVerticle extends AbstractVerticle {
   private HttpServer server;
   private CrudApis crudApis;
   private SearchApis searchApis;
+  private String keystore;
+  private String keystorePassword;
   private ListApis listApis;
   private RelationshipApis relApis;
   private GeocodingApis geoApis;
@@ -56,7 +58,7 @@ public class ApiServerVerticle extends AbstractVerticle {
   private Router router;
 
   private String catAdmin;
-  private boolean isSsl;
+  private boolean isSSL;
   private int port;
 
 
@@ -74,23 +76,43 @@ public class ApiServerVerticle extends AbstractVerticle {
 
     /* Configure */
     catAdmin = config().getString(CAT_ADMIN);
-    isSsl = config().getBoolean(IS_SSL);
-    port = config().getInteger(PORT);
+    isSSL = config().getBoolean(IS_SSL);
 
 
     HttpServerOptions serverOptions = new HttpServerOptions();
 
-    /*
-    if (isSsl) {
+
+    if (isSSL) {
+      LOGGER.debug("Info: Starting HTTPs server");
+
+      /* Read the configuration and set the HTTPs server properties. */
+
+      keystore = config().getString("keystore");
+      keystorePassword = config().getString("keystorePassword");
+      
+      /*
+       * Default port when ssl is enabled is 8443. If set through config, then that value is taken
+       */
+      port = config().getInteger(PORT) == null ? 8443
+          : config().getInteger(PORT);
+
+      /* Setup the HTTPs server properties, APIs and port. */
+
       serverOptions.setSsl(true)
-                    .setKeyStoreOptions(new JksOptions()
-                                          .setPath(keystore)
-                                          .setPassword(keystorePassword));
+          .setKeyStoreOptions(new JksOptions().setPath(keystore).setPassword(keystorePassword));
+
     } else {
+      LOGGER.debug("Info: Starting HTTP server");
+
+      /* Setup the HTTP server properties, APIs and port. */
+
       serverOptions.setSsl(false);
+      /*
+       * Default port when ssl is disabled is 8080. If set through config, then that value is taken
+       */
+      port = config().getInteger(PORT) == null ? 8080
+          : config().getInteger(PORT);
     }
-    */
-    serverOptions.setSsl(false);
     serverOptions.setCompressionSupported(true).setCompressionLevel(5);
     /** Instantiate this server */
     server = vertx.createHttpServer(serverOptions);

--- a/src/main/java/iudx/catalogue/server/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/util/Constants.java
@@ -23,7 +23,7 @@ public class Constants {
   public static final String CONFIG_FILE = "config.properties";
   public static final String OPTIONAL_MODULES = "optionalModules";
   public static final String IS_SSL = "ssl";
-  public static final String PORT = "port";
+  public static final String PORT = "httpPort";
   public static final String KEYSTORE_PATH = "keystorePath";
   public static final String KEYSTORE_PASSWORD = "keystorePassword";
   public static final String DATABASE_IP = "databaseIP";

--- a/src/test/java/iudx/catalogue/server/apiserver/ApiServerVerticlePreprareTest.java
+++ b/src/test/java/iudx/catalogue/server/apiserver/ApiServerVerticlePreprareTest.java
@@ -59,7 +59,7 @@ public class ApiServerVerticlePreprareTest {
     String keyStore = apiVerticleConfig.getString(KEYSTORE_PATH);
     String keyStorePassword = apiVerticleConfig.getString(KEYSTORE_PASSWORD);
     HOST = apiVerticleConfig.getString("ip");
-    PORT = apiVerticleConfig.getInteger("port");
+    PORT = apiVerticleConfig.getInteger("httpPort");
     TOKEN = apiVerticleConfig.getString(HEADER_TOKEN);
     ADMIN_TOKEN = apiVerticleConfig.getString("admin_token");
     

--- a/src/test/java/iudx/catalogue/server/apiserver/ApiServerVerticleTest.java
+++ b/src/test/java/iudx/catalogue/server/apiserver/ApiServerVerticleTest.java
@@ -69,7 +69,7 @@ public class ApiServerVerticleTest {
     String keyStore = apiVerticleConfig.getString(KEYSTORE_PATH);
     String keyStorePassword = apiVerticleConfig.getString(KEYSTORE_PASSWORD);
     HOST = apiVerticleConfig.getString("ip");
-    PORT = apiVerticleConfig.getInteger("port");
+    PORT = apiVerticleConfig.getInteger("httpPort");
     TOKEN = apiVerticleConfig.getString(HEADER_TOKEN);
     ADMIN_TOKEN = apiVerticleConfig.getString("admin_token");
     

--- a/src/test/java/iudx/catalogue/server/apiserver/IntegrationTest.java
+++ b/src/test/java/iudx/catalogue/server/apiserver/IntegrationTest.java
@@ -118,7 +118,7 @@ public class IntegrationTest {
     String keyStore = apiVerticleConfig.getString(KEYSTORE_PATH);
     String keyStorePassword = apiVerticleConfig.getString(KEYSTORE_PASSWORD);
     HOST = apiVerticleConfig.getString("ip");
-    PORT = apiVerticleConfig.getInteger("port");
+    PORT = apiVerticleConfig.getInteger("httpPort");
     TOKEN = apiVerticleConfig.getString(HEADER_TOKEN);
     ADMIN_TOKEN = apiVerticleConfig.getString("admin_token");
    

--- a/src/test/java/iudx/catalogue/server/apiserver/ServerVerticleDeboardTest.java
+++ b/src/test/java/iudx/catalogue/server/apiserver/ServerVerticleDeboardTest.java
@@ -70,7 +70,7 @@ public class ServerVerticleDeboardTest {
     JsonObject apiVerticleConfig = Configuration.getConfiguration("./configs/config-test.json", 3);
 
     HOST = apiVerticleConfig.getString("ip");
-    PORT = apiVerticleConfig.getInteger("port");
+    PORT = apiVerticleConfig.getInteger("httpPort");
     TOKEN = apiVerticleConfig.getString(HEADER_TOKEN);
     ADMIN_TOKEN = apiVerticleConfig.getString("admin_token");
 


### PR DESCRIPTION
- default http port is 8080, https is 8443 (non-standard ports)
- changed option name to configure apiserver port to be httpPort
- added auditing verticle config config-example