### PR TITLE
Updated to refer configs archived for release 3.5.0 in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
         node('master') {
           script{
             startZap ([host: 'localhost', port: 8090, zapHome: '/var/lib/jenkins/tools/com.cloudbees.jenkins.plugins.customtools.CustomTool/OWASP_ZAP/ZAP_2.11.0'])
-            sh 'HTTP_PROXY=\'127.0.0.1:8090\' newman run /var/lib/jenkins/iudx/cat/Newman/iudx-catalogue-server-v3.5.postman_collection_test.json -e /home/ubuntu/configs/cat-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/cat/Newman/report/report.html --reporter-htmlextra-skipSensitiveData'
+            sh 'HTTP_PROXY=\'127.0.0.1:8090\' newman run /var/lib/jenkins/iudx/cat/Newman/iudx-catalogue-server-v3.5.postman_collection_test.json -e /home/ubuntu/configs/3.5.0/cat-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/cat/Newman/report/report.html --reporter-htmlextra-skipSensitiveData'
             runZapAttack()
           }
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - WORKSPACE
       - LOG_LEVEL=INFO
     volumes:
-      - /home/ubuntu/configs/cat-config-test.json:/usr/share/app/configs/config-test.json
+      - /home/ubuntu/configs/3.5.0/cat-config-test.json:/usr/share/app/configs/config-test.json
       - ./src/:/usr/share/app/src
       - ./docker/runTests.sh:/usr/share/app/docker/runTests.sh
       - ${WORKSPACE}:/tmp/test
@@ -81,7 +81,7 @@ services:
       - WORKSPACE
       - LOG_LEVEL=INFO
     volumes:
-      - /home/ubuntu/configs/cat-config-test.json:/usr/share/app/configs/config-test.json
+      - /home/ubuntu/configs/3.5.0/cat-config-test.json:/usr/share/app/configs/config-test.json
       - ./src/:/usr/share/app/src
     ports:
       - "8080:8080"


### PR DESCRIPTION
Until now the same config files were being used in all the pipelines (master/PR/3.5.0). But since testing the v4.0 components (master and PR CI) might require changes in the config files, it could end up affecting v3.5.0 CI pipelines.
To avoid this, archiving the current configs for the 3.5.0 pipelines separately and updated references in the CI tests to refer to those.