### PR TITLE
software updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-jdbc-client</artifactId>
-            <version>4.1.1</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
@@ -89,7 +88,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web-client</artifactId>
-            <version>4.0.3</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
@@ -194,12 +192,10 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-auth-jwt</artifactId>
-            <version>4.0.3</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-pg-client</artifactId>
-            <version>4.0.3</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,23 +7,23 @@
     <artifactId>iudx.catalogue.server</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <properties>
-        <vertx.version>4.0.3</vertx.version>
+        <vertx.version>4.3.2</vertx.version>
         <openjdk.version>11</openjdk.version>
         <hazelcast.version>4.0.2</hazelcast.version>
-        <micrometer.version>1.6.2</micrometer.version>
-        <curator.version>5.1.0</curator.version>
-        <junit-jupiter-engine.version>5.7.1</junit-jupiter-engine.version>
+        <micrometer.version>1.9.2</micrometer.version>
+        <curator.version>5.3.0</curator.version>
+        <junit-jupiter-engine.version>5.8.2</junit-jupiter-engine.version>
         <apache-log4j2.version>2.17.1</apache-log4j2.version>
         <lmax-disruptor.version>3.4.4</lmax-disruptor.version>
-        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
-        <checkstyle.version>8.42</checkstyle.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
-        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <maven-pmd-plugin.version>3.14.0</maven-pmd-plugin.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
+        <checkstyle.version>10.3.1</checkstyle.version>
+        <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+        <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
+        <maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
+        <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
+        <maven-pmd-plugin.version>3.17.0</maven-pmd-plugin.version>
         <maven-checkstyle-plugin-google.version>3.1.2</maven-checkstyle-plugin-google.version>
-        <maven-surefire-report-plugin.version>3.0.0-M5</maven-surefire-report-plugin.version>
+        <maven-surefire-report-plugin.version>3.0.0-M7</maven-surefire-report-plugin.version>
         <elastic-search-rest-client>7.7.1</elastic-search-rest-client>
         <slf4j.version>1.7.25</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -177,18 +177,18 @@
         <dependency>
             <groupId>io.qameta.allure</groupId>
             <artifactId>allure-junit5</artifactId>
-            <version>2.13.6</version>
+            <version>2.19.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-commons</artifactId>
-			<version>1.7.0</version>
+			<version>1.9.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-engine</artifactId>
-			<version>1.7.0</version>
+			<version>1.9.0</version>
 			<scope>test</scope>
 		</dependency>
         <dependency>

--- a/src/main/java/iudx/catalogue/server/apiserver/CrudApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/CrudApis.java
@@ -93,7 +93,7 @@ public final class CrudApis {
     LOGGER.debug("Info: Creating/Updating item");
 
     /* Contains the cat-item */
-    JsonObject requestBody = routingContext.getBodyAsJson();
+    JsonObject requestBody = routingContext.body().asJsonObject();
     HttpServerRequest request = routingContext.request();
     HttpServerResponse response = routingContext.response();
     JsonObject jwtAuthenticationInfo = new JsonObject();

--- a/src/main/java/iudx/catalogue/server/apiserver/RatingApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/RatingApis.java
@@ -68,7 +68,7 @@ public class RatingApis {
   public void createRatingHandler(RoutingContext routingContext) {
     LOGGER.debug("Info: Creating Rating");
 
-    JsonObject requestBody = routingContext.getBodyAsJson();
+    JsonObject requestBody = routingContext.body().asJsonObject();
     HttpServerRequest request = routingContext.request();
     HttpServerResponse response = routingContext.response();
 
@@ -207,7 +207,7 @@ public class RatingApis {
   public void updateRatingHandler(RoutingContext routingContext) {
     LOGGER.debug("Info: Updating Rating");
 
-    JsonObject requestBody = routingContext.getBodyAsJson();
+    JsonObject requestBody = routingContext.body().asJsonObject();
     HttpServerRequest request = routingContext.request();
     HttpServerResponse response = routingContext.response();
 

--- a/src/test/java/iudx/catalogue/server/rating/RatingServiceTest.java
+++ b/src/test/java/iudx/catalogue/server/rating/RatingServiceTest.java
@@ -43,7 +43,7 @@ public class RatingServiceTest {
   @BeforeAll
   @DisplayName("Initialize vertx and deploy verticle")
   public static void init(Vertx vertx, VertxTestContext testContext) {
-    config = Configuration.getConfiguration("./configs/config-test.json", 5);
+    config = Configuration.getConfiguration("./configs/config-test.json", 7);
     exchangeName = config.getString("exchangeName");
     rsauditingtable = config.getString("rsAuditingTableName");
     minReadNumber = config.getInteger("minReadNumber");
@@ -76,7 +76,7 @@ public class RatingServiceTest {
   @DisplayName("Success: test create rating")
   void successfulRatingCreationTest(VertxTestContext testContext) {
     JsonObject request = requestJson();
-    JsonObject auditInfo = new JsonObject().put("totalHits", 1);
+    JsonObject auditInfo = new JsonObject().put("totalHits", minReadNumber + 1);
 
     doAnswer(Answer -> Future.succeededFuture(auditInfo))
         .when(ratingServiceSpy)
@@ -104,7 +104,7 @@ public class RatingServiceTest {
         handler -> {
           if (handler.succeeded()) {
             verify(ratingServiceSpy, times(2)).getAuditingInfo(any());
-            verify(databaseService, times(2)).createRating(any(), any());
+            verify(databaseService, times(1)).createRating(any(), any());
             testContext.completeNow();
           } else {
             LOGGER.debug("Fail");


### PR DESCRIPTION
#### Dependencies/lib updates to latest stable releases

1.  Vertx version bump to 4.3.2 from 4.0.3
      -  Requires changing `context.getBodyAsJson()` to `context.body().asJsonObject()`
2.  Dependencies upgraded to latest stable release

| dependency | old version | new version |
|:---:|---|---|
| micrometer | 1.6.2 | 1.9.2 |
| curator | 5.1.0 | 5.3.0 |
| junit-jupiter-engine | 5.7.2 | 5.8.2 |
| junit-jupiter-params | 5.7.2 | 5.8.2 |
| jacoco | 0.8.7 | 0.8.8 |
| checkstyle(puppycrawl) | 8.4.2 | 10.3.1 |
| shade plugin | 3.2.4 | 3.3.0 |
| javadocs plugin | 3.2.0 | 3.4.0 |
| exec plugin | 3.0.0 | 3.1.0 |
| surefire pluigin | 3.0.0-M5 | 3.0.0-M7 |
| mvn compile plugin | 3.8.1 | 3.10.1 |
| pmd plugin | 3.14.0 | 3.17.0 |
| surefire-plugin | 3.0.0-M5 | 3.0.0-M7 |
| qameta allure | 2.13.6 | 2.19.0 |
| junit-platform-commons | 1.7.0 | 1.9.0 |
|junit-platform-engine | 1.7.0 | 1.9.0 |