### PR TITLE
Add dockerisation of profanity check

### DIFF
--- a/src/main/profanity-check-sdk/.dockerignore
+++ b/src/main/profanity-check-sdk/.dockerignore
@@ -1,0 +1,1 @@
+config.json

--- a/src/main/profanity-check-sdk/Dockerfile
+++ b/src/main/profanity-check-sdk/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update \
 
 RUN useradd -r -u 1001 -g root profanity-user
 USER profanity-user
-CMD ["python","main.py"]
+CMD ["python","-W", "ignore", "main.py"]

--- a/src/main/profanity-check-sdk/Dockerfile
+++ b/src/main/profanity-check-sdk/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.8-slim
+WORKDIR /usr/share/app
+COPY . /usr/share/app/
+COPY requirements.txt .
+
+RUN apt-get update \
+    && /usr/local/bin/python -m pip install --upgrade pip \
+    && pip install --no-cache-dir  -r requirements.txt 
+
+RUN useradd -r -u 1001 -g root profanity-user
+USER profanity-user
+CMD ["python","main.py"]

--- a/src/main/profanity-check-sdk/requirements.txt
+++ b/src/main/profanity-check-sdk/requirements.txt
@@ -1,5 +1,5 @@
 cuss_inspect==1.0.2b0
-elasticsearch==8.4.1
+elasticsearch==7.17.6
 elasticsearch_dsl==7.4.0
 numpy==1.23.3
 pika==1.3.0


### PR DESCRIPTION
- correct requirements txt to use elasticsearch==7.17.6  because ``` The conflict is caused by: The user requested elasticsearch==8.4.1 elasticsearch-dsl 7.4.0 depends on elasticsearch<8.0.0 and >=7.0.0 ```