### PR TITLE
Make server base path configurable

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -25,8 +25,9 @@ info:
         - **Base path**:
           - Base path is the path on which API is served, relative to the host
           - It is the initial part of the API
-          - Currently, `/iudx/cat/v1` is being used as base path
-          - This value could be configured according to the deployment
+          - The base path for [DX AAA Server](https://github.com/datakaveri/iudx-aaa-server) is set to `/auth/v1`
+          - Currently, `/iudx/cat/v1` is being used as base path for all the DX Catalogue Server APIs
+          - These value could be configured according to the deployment
         - **Request Samples**:
           - The `<tokeValue>` in the header of request sample could be replaced with respective token value that could be obtained from DX Auth Server
           - The `<payload>` in the request sample could be replaced with the payload given adjacent to the request sample

--- a/src/main/java/iudx/catalogue/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/ApiServerVerticle.java
@@ -68,6 +68,7 @@ public class ApiServerVerticle extends AbstractVerticle {
   private int port;
 
   private String dxApiBasePath;
+  private String dxAuthBasePath;
   private Api api;
 
   private static final Logger LOGGER = LogManager.getLogger(ApiServerVerticle.class);
@@ -83,6 +84,7 @@ public class ApiServerVerticle extends AbstractVerticle {
     router = Router.router(vertx);
 
     dxApiBasePath = config().getString("dxApiBasePath");
+    dxAuthBasePath = config().getString("dxAuthBasePath");
     api = Api.getInstance(dxApiBasePath);
 
     /* Configure */

--- a/src/main/java/iudx/catalogue/server/authenticator/AuthenticationServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/AuthenticationServiceImpl.java
@@ -36,10 +36,12 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     private static final Logger LOGGER = LogManager.getLogger(AuthenticationServiceImpl.class);
     static WebClient webClient;
     private String authHost;
+    private JsonObject config;
 
-    public AuthenticationServiceImpl(WebClient client, String authHost) {
+    public AuthenticationServiceImpl(WebClient client, String authHost, JsonObject config) {
         webClient = client;
         this.authHost = authHost;
+        this.config = config;
     }
 
     static void validateAuthInfo(JsonObject authInfo) throws IllegalArgumentException {
@@ -84,8 +86,9 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
         JsonObject body = new JsonObject();
         body.put(TOKEN, authenticationInfo.getString(TOKEN));
+        String tokenIntrospectPath = config.getString("dxAuthBasePath") + AUTH_TIP_PATH;
         webClient
-            .post(443, authHost, AUTH_TIP_PATH)
+            .post(443, authHost, tokenIntrospectPath)
                 .expect(ResponsePredicate.JSON)
                 .sendJsonObject(body, httpResponseAsyncResult -> {
                     if (httpResponseAsyncResult.failed()) {

--- a/src/main/java/iudx/catalogue/server/authenticator/AuthenticationVerticle.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/AuthenticationVerticle.java
@@ -114,7 +114,8 @@ public class AuthenticationVerticle extends AbstractVerticle {
     if (config.containsKey(PUBLIC_KEY)) {
       promise.complete(config.getString(PUBLIC_KEY));
     } else {
-      webClient.get(443, config.getString("authServerHost"), "/auth/v1/cert")
+      String authCert = config.getString("dxAuthBasePath") + AUTH_CERTIFICATE_PATH;
+      webClient.get(443, config.getString("authServerHost"), authCert)
               .send(handler -> {
                 if (handler.succeeded()) {
                   JsonObject json = handler.result().bodyAsJsonObject();

--- a/src/main/java/iudx/catalogue/server/authenticator/Constants.java
+++ b/src/main/java/iudx/catalogue/server/authenticator/Constants.java
@@ -3,10 +3,9 @@ package iudx.catalogue.server.authenticator;
 public class Constants {
 
     public static final String AUTH_SERVER_HOST = "authServerHost";
-    public static final String AUTH_CERTINFO_PATH = "/auth/v1/certificate-info";
     public static final String DUMMY_TOKEN_KEY = "authDummyToken";
     public static final String DUMMY_PROVIDER_PREFIX = "datakaveri.org/f7e044eee8122b5c87dce6e7ad64f3266afa41dc";
-    public static final String AUTH_TIP_PATH = "/auth/v1/token/introspect";
+    public static final String AUTH_TIP_PATH = "/token/introspect";
 
     public static final String TOKEN = "token";
     public static final String OPERATION = "operation";
@@ -20,6 +19,7 @@ public class Constants {
 
     /* JWT specific */
     public static final String JSON_USERID = "userid";
+    public static final String AUTH_CERTIFICATE_PATH = "/cert";
     public static final String API_ENDPOINT = "apiEndpoint";
     public static final String METHOD = "method";
 //    public static final String ITEM_ENDPOINT = "/iudx/cat/v1/item";

--- a/src/test/java/iudx/catalogue/server/authenticator/AuthenticationServiceImplTest.java
+++ b/src/test/java/iudx/catalogue/server/authenticator/AuthenticationServiceImplTest.java
@@ -12,6 +12,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import iudx.catalogue.server.apiserver.SearchApis;
 import jdk.jfr.Description;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -41,15 +42,24 @@ public class AuthenticationServiceImplTest {
   @Mock AsyncResult<HttpResponse<Buffer>> httpResponseAsyncResult;
 
   private JsonObject config;
+
+  @BeforeEach
+  public void setUp(VertxTestContext vertxTestContext)
+  {
+    config = new JsonObject();
+
+    config.put("dxApiBasePath", "/iudx/cat/v1");
+    config.put("dxAuthBasePath", "/auth/v1");
+    authenticationService = new AuthenticationServiceImpl(webClient, "dummy", config);
+
+    vertxTestContext.completeNow();
+  }
   @Test
   @Description("testing the method validateAuthInfo")
   public void testValidateAuthInfo(VertxTestContext vertxTestContext) {
     String authHost = "dummy";
     authenticationInfo = new JsonObject();
-    config = new JsonObject();
 
-    config.put("dxApiBasePath", "/iudx/cat/v1");
-    config.put("dxAuthBasePath", "/auth/v1");
 
     request = new JsonObject();
     authenticationInfo.put(TOKEN, "dummy");
@@ -131,7 +141,6 @@ public class AuthenticationServiceImplTest {
         .when(httpRequest)
         .sendJsonObject(any(), any());
 
-    authenticationService = new AuthenticationServiceImpl(webClient, authHost, config);
     authenticationService.tokenInterospect(
         request,
         authenticationInfo,

--- a/src/test/java/iudx/catalogue/server/authenticator/AuthenticationServiceImplTest.java
+++ b/src/test/java/iudx/catalogue/server/authenticator/AuthenticationServiceImplTest.java
@@ -40,11 +40,17 @@ public class AuthenticationServiceImplTest {
   @Mock JsonObject json;
   @Mock AsyncResult<HttpResponse<Buffer>> httpResponseAsyncResult;
 
+  private JsonObject config;
   @Test
   @Description("testing the method validateAuthInfo")
   public void testValidateAuthInfo(VertxTestContext vertxTestContext) {
     String authHost = "dummy";
     authenticationInfo = new JsonObject();
+    config = new JsonObject();
+
+    config.put("dxApiBasePath", "/iudx/cat/v1");
+    config.put("dxAuthBasePath", "/auth/v1");
+
     request = new JsonObject();
     authenticationInfo.put(TOKEN, "dummy");
     authenticationInfo.put(OPERATION, "dummy");
@@ -68,7 +74,7 @@ public class AuthenticationServiceImplTest {
         .when(httpRequest)
         .sendJsonObject(any(), any());
 
-    authenticationService = new AuthenticationServiceImpl(webClient, authHost);
+    authenticationService = new AuthenticationServiceImpl(webClient, authHost, config);
     authenticationService.tokenInterospect(
         request,
         authenticationInfo,
@@ -125,7 +131,7 @@ public class AuthenticationServiceImplTest {
         .when(httpRequest)
         .sendJsonObject(any(), any());
 
-    authenticationService = new AuthenticationServiceImpl(webClient, authHost);
+    authenticationService = new AuthenticationServiceImpl(webClient, authHost, config);
     authenticationService.tokenInterospect(
         request,
         authenticationInfo,
@@ -147,7 +153,7 @@ public class AuthenticationServiceImplTest {
   public void testIsPermittedMethodTrue(VertxTestContext vertxTestContext) {
 
     String authHost = "dummy";
-    authenticationService = new AuthenticationServiceImpl(webClient, authHost);
+    authenticationService = new AuthenticationServiceImpl(webClient, authHost, config);
     JsonArray methods = new JsonArray();
     methods.add("*");
     String operation = "dummy";
@@ -160,7 +166,7 @@ public class AuthenticationServiceImplTest {
   public void testIsPermittedMethodFalse(VertxTestContext vertxTestContext) {
 
     String authHost = "dummy value";
-    authenticationService = new AuthenticationServiceImpl(webClient, authHost);
+    authenticationService = new AuthenticationServiceImpl(webClient, authHost, config);
     JsonArray methods = new JsonArray();
     methods.add("dummyy");
     String operation = "dummy";
@@ -178,7 +184,7 @@ public class AuthenticationServiceImplTest {
     authenticationInfo.put(OPERATION, "");
     request.put(PROVIDER, "dummy");
     AuthenticationServiceImpl.webClient = mock(WebClient.class);
-    authenticationService = new AuthenticationServiceImpl(webClient, authHost);
+    authenticationService = new AuthenticationServiceImpl(webClient, authHost, config);
     assertNotNull(authenticationService.tokenInterospect(request, authenticationInfo, handler));
     vertxTestContext.completeNow();
   }
@@ -193,7 +199,7 @@ public class AuthenticationServiceImplTest {
     authenticationInfo.put(OPERATION, "dummy");
     request.put(PROVIDER, "dummy");
     AuthenticationServiceImpl.webClient = mock(WebClient.class);
-    authenticationService = new AuthenticationServiceImpl(webClient, authHost);
+    authenticationService = new AuthenticationServiceImpl(webClient, authHost, config);
     assertNotNull(authenticationService.tokenInterospect(request, authenticationInfo, handler));
     vertxTestContext.completeNow();
   }

--- a/src/test/java/iudx/catalogue/server/authenticator/AuthenticationServiceImplTest.java
+++ b/src/test/java/iudx/catalogue/server/authenticator/AuthenticationServiceImplTest.java
@@ -8,6 +8,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.impl.predicate.ResponsePredicateImpl;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import iudx.catalogue.server.apiserver.SearchApis;
@@ -43,17 +44,7 @@ public class AuthenticationServiceImplTest {
 
   private JsonObject config;
 
-  @BeforeEach
-  public void setUp(VertxTestContext vertxTestContext)
-  {
-    config = new JsonObject();
 
-    config.put("dxApiBasePath", "/iudx/cat/v1");
-    config.put("dxAuthBasePath", "/auth/v1");
-    authenticationService = new AuthenticationServiceImpl(webClient, "dummy", config);
-
-    vertxTestContext.completeNow();
-  }
   @Test
   @Description("testing the method validateAuthInfo")
   public void testValidateAuthInfo(VertxTestContext vertxTestContext) {
@@ -83,6 +74,10 @@ public class AuthenticationServiceImplTest {
             })
         .when(httpRequest)
         .sendJsonObject(any(), any());
+    config = new JsonObject();
+
+    config.put("dxApiBasePath", "/iudx/cat/v1");
+    config.put("dxAuthBasePath", "/auth/v1");
 
     authenticationService = new AuthenticationServiceImpl(webClient, authHost, config);
     authenticationService.tokenInterospect(
@@ -124,6 +119,13 @@ public class AuthenticationServiceImplTest {
     when(webClient.post(anyInt(), anyString(), anyString())).thenReturn(httpRequest);
     when(httpRequest.expect(any())).thenReturn(httpRequest);
     when(httpResponseAsyncResult.result()).thenReturn(httpResponse);
+
+    config = new JsonObject();
+
+    config.put("dxApiBasePath", "/iudx/cat/v1");
+    config.put("dxAuthBasePath", "/auth/v1");
+    authenticationService = new AuthenticationServiceImpl(webClient, "dummy", config);
+
 
     when(httpResponse.statusCode()).thenReturn(200);
     when(httpResponse.bodyAsJsonObject()).thenReturn(json);

--- a/src/test/java/iudx/catalogue/server/authenticator/JwtAuthServiceImplTest.java
+++ b/src/test/java/iudx/catalogue/server/authenticator/JwtAuthServiceImplTest.java
@@ -29,6 +29,7 @@ public class JwtAuthServiceImplTest {
 
   private static final Logger LOGGER = LogManager.getLogger(JwtAuthServiceImplTest.class);
   private static JsonObject authConfig;
+  private static final String AUTH_CERTINFO_PATH = "/auth/v1/certificate-info";
   private static JwtAuthenticationServiceImpl jwtAuthenticationService;
   private static AuthenticationService authenticationService;
   private static Vertx vertxObj;
@@ -83,7 +84,7 @@ public class JwtAuthServiceImplTest {
   public void testWebClientSetup(Vertx vertx, VertxTestContext testContext) {
     WebClient client = AuthenticationVerticle.createWebClient(vertx, authConfig, true);
     String host = authConfig.getString(Constants.AUTH_SERVER_HOST);
-    client.post(443, host, Constants.AUTH_CERTINFO_PATH).send(httpResponseAsyncResult -> {
+    client.post(443, host, AUTH_CERTINFO_PATH).send(httpResponseAsyncResult -> {
       if (httpResponseAsyncResult.failed()) {
         LOGGER.error("Cert info call failed");
         testContext.failNow(httpResponseAsyncResult.cause());

--- a/src/test/resources/README.md
+++ b/src/test/resources/README.md
@@ -1,8 +1,8 @@
 ### Making configurable base path
 - Base path can be added in postman environment file or in postman.
-- `iudx-catalogue-server-v4.0.postman-env.json` has **values** array which has a field named **base** whose **value** is currently set to `iudx/cat/v1`.
+- `iudx-catalogue-server-v4.0.postman-env.json` has **values** array that contain fields named **base** whose **value** is currently set to `iudx/cat/v1`, **dxAuthBasePath** with value `auth/v1`.
 - The **value** could be changed according to the deployment and then the collection with the `iudx-catalogue-server-v4.0.postman-env.json` file can be uploaded to Postman
-- For the changing the **base** value in postman after importing the collection and environment files, locate `CAT Environment` from **Environments** in sidebar of Postman application.
+- For the changing the **base**, **dxAuthBasePath** value in postman after importing the collection and environment files, locate `CAT Environment` from **Environments** in sidebar of Postman application.
 - To know more about Postman environments, refer : [postman environments](https://learning.postman.com/docs/sending-requests/managing-environments/)
 - The **CURRENT VALUE** of the variable could be changed
 

--- a/src/test/resources/iudx-catalogue-server-v4.5.0.postman-env.json
+++ b/src/test/resources/iudx-catalogue-server-v4.5.0.postman-env.json
@@ -19,6 +19,11 @@
 			"enabled": true
 		},
 		{
+			"key": "dxAuthBasePath",
+			"value": "auth/v1",
+			"enabled": true
+		},
+		{
 			"key": "adminToken",
 			"value": "",
 			"type": "default",

--- a/src/test/resources/iudx-catalogue-server-v4.5.0.postman_collection.json
+++ b/src/test/resources/iudx-catalogue-server-v4.5.0.postman_collection.json
@@ -48,14 +48,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -116,14 +115,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -184,14 +182,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}


### PR DESCRIPTION
- Referencing datakaveri/iudx-resource-server#368
- Made Catalogue Server base path `iudx/cat/v1`, AAA Server base path `auth/v1` configurable by [updating the files](https://github.com/datakaveri/iudx-catalogue-server/pull/214/commits/b230499bc2a92a837cda6fe2bf7ac97421a62f9c). 
- - Changes made in config-dev : 
```
  "commonConfig" :  {
    "dxApiBasePath" : "/iudx/cat/v1",
    "dxAuthBasePath": "/auth/v1"
  },
```
- Changes made in Postman environment file : 
```
     {
       "key": "dxAuthBasePath",
        "value": "auth/v1",
	"enabled": true
       },