### PR TITLE
instance based filtration added in Provider API

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -33,6 +33,7 @@ info:
        - <b>/internal/ui/providers</b>
        - <b>/internal/ui/instance</b>
        - <b>/internal/ui/domain</b>
+       - <b>/internal/ui/dataset</b>
        
     Additional query parameters to be used:
       - <b>offset</b> : The from parameter defines the offset from the first result you want to fetch,  ( <i>default : 0</i> ,<i>minValue: 0</i>, <i>maxValue: 10000</i> )
@@ -2038,6 +2039,12 @@ paths:
             `offset` of the data model domain, to be fetched
           schema:
             type: string
+        - name: instance
+          in: query
+          description: |
+            `name` of the instance from where the dataset information has to be fetched
+          schema:
+            type: string
       responses:
         '200':
           description: Success
@@ -2105,6 +2112,19 @@ paths:
       description: |
         Fetches details of all the datasets.
       operationId: get datasets
+      parameters:
+        - name: limit
+          in: query
+          description: |
+            `limit` of the data model domain, to be fetched
+          schema:
+            type: string
+        - name: offset
+          in: query
+          description: |
+            `offset` of the data model domain, to be fetched
+          schema:
+            type: string
       responses:
         '200':
           description: Successfully fetched
@@ -2125,6 +2145,19 @@ paths:
         - Mlayer Dataset
       description: Fetches the dataset details of a particular dataset using dataset_id. Domains, Instance, Tags and provider field can be used to filter the datasets.
       operationId: get dataset and its resources
+      parameters:
+        - name: limit
+          in: query
+          description: |
+            `limit` of the data model domain, to be fetched
+          schema:
+            type: string
+        - name: offset
+          in: query
+          description: |
+            `offset` of the data model domain, to be fetched
+          schema:
+            type: string
       requestBody:
         description: 'Based on id dataset and its resources are retrieved. If id field blank or not present then, tags, providers and instance can be used to filter from all datasets.'
         required: true

--- a/src/main/java/iudx/catalogue/server/apiserver/MlayerApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/MlayerApis.java
@@ -536,6 +536,11 @@ public class MlayerApis {
     HttpServerResponse response = routingContext.response();
     response.putHeader(HEADER_CONTENT_TYPE, MIME_APPLICATION_JSON);
     JsonObject requestParams = parseRequestParams(routingContext);
+    if (routingContext.request().getParam(INSTANCE) != null) {
+      routingContext.request().getParam(INSTANCE);
+      requestParams.put(INSTANCE, routingContext.request().getParam(INSTANCE));
+      LOGGER.debug("Instance {}", requestParams.getString(INSTANCE));
+    }
     mlayerService.getMlayerProviders(
         requestParams,
         handler -> {

--- a/src/main/java/iudx/catalogue/server/database/mlayer/MlayerProvider.java
+++ b/src/main/java/iudx/catalogue/server/database/mlayer/MlayerProvider.java
@@ -1,14 +1,19 @@
 package iudx.catalogue.server.database.mlayer;
 
-import static iudx.catalogue.server.database.Constants.GET_MLAYER_PROVIDERS_QUERY;
+import static iudx.catalogue.server.database.Constants.*;
 import static iudx.catalogue.server.util.Constants.*;
+import static iudx.catalogue.server.validator.Constants.VALIDATION_FAILURE_MSG;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import iudx.catalogue.server.database.ElasticClient;
 import iudx.catalogue.server.database.RespBuilder;
+import iudx.catalogue.server.database.Util;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -32,19 +37,109 @@ public class MlayerProvider {
       JsonObject requestParams, Handler<AsyncResult<JsonObject>> handler) {
     String limit = requestParams.getString(LIMIT);
     String offset = requestParams.getString(OFFSET);
-    String query = GET_MLAYER_PROVIDERS_QUERY.replace("$0", limit).replace("$1", offset);
-    client.searchAsync(
-        query,
-        docIndex,
-        resultHandler -> {
-          if (resultHandler.succeeded()) {
-            LOGGER.debug("Success: Successful DB Request");
-            JsonObject result = resultHandler.result();
-            handler.handle(Future.succeededFuture(result));
-          } else {
-            LOGGER.error("Fail: failed DB request");
-            handler.handle(Future.failedFuture(internalErrorResp));
-          }
+    if (requestParams.containsKey(INSTANCE)) {
+      String query = GET_DATASET_BY_INSTANCE.replace("$1", requestParams.getString(INSTANCE));
+      client.searchAsyncResourceGroupAndProvider(
+          query,
+          docIndex,
+          resultHandler -> {
+            if (resultHandler.succeeded()) {
+              LOGGER.debug("Success: Successful DB Request");
+              // providerCount depicts the number of provider associated with the instance
+              Integer providerCount =
+                  resultHandler
+                      .result()
+                      .getJsonArray(RESULTS)
+                      .getJsonObject(0)
+                      .getInteger("providerCount");
+              LOGGER.debug("provider Count {} ", providerCount);
+              // results consists of all providers and resource groups belonging to instance
+              JsonArray results =
+                  resultHandler
+                      .result()
+                      .getJsonArray(RESULTS)
+                      .getJsonObject(0)
+                      .getJsonArray("resourceGroupAndProvider");
+              int resultSize = results.size();
+              // 'allProviders' is a mapping of provider IDs to their corresponding JSON objects
+              Map<String, JsonObject> allProviders = new HashMap<>();
+              JsonArray providersList = new JsonArray();
+              // creating mapping of all provider IDs to their corresponding JSON objects
+              for (int i = 0; i < resultSize; i++) {
+                JsonObject provider = results.getJsonObject(i);
+                String itemType = Util.getItemType(provider);
+                if (itemType.equals(VALIDATION_FAILURE_MSG)) {
+                  handler.handle(Future.failedFuture(VALIDATION_FAILURE_MSG));
+                }
+                if (ITEM_TYPE_PROVIDER.equals(itemType)) {
+                  allProviders.put(
+                      provider.getString(ID),
+                      new JsonObject()
+                          .put(ID, provider.getString(ID))
+                          .put(DESCRIPTION_ATTR, provider.getString(DESCRIPTION_ATTR)));
+                }
+              }
+              // filtering out providers which belong to the instance from all providers map.
+              for (int i = 0; i < resultSize; i++) {
+                JsonObject resourceGroup = results.getJsonObject(i);
+                String itemType = Util.getItemType(resourceGroup);
+                if (itemType.equals(VALIDATION_FAILURE_MSG)) {
+                  handler.handle(Future.failedFuture(VALIDATION_FAILURE_MSG));
+                }
+                if (ITEM_TYPE_RESOURCE_GROUP.equals(itemType)
+                    && allProviders.containsKey(resourceGroup.getString(PROVIDER))) {
+                  providersList.add(allProviders.get(resourceGroup.getString(PROVIDER)));
+                  allProviders.remove(resourceGroup.getString(PROVIDER));
+                }
+              }
+              LOGGER.debug("provider belonging to instance are {} ", providersList);
+              // Pagination applied to the final response.
+              int endIndex = requestParams.getInteger(LIMIT) + requestParams.getInteger(OFFSET);
+              if (endIndex >= providerCount) {
+                if (requestParams.getInteger(OFFSET) >= providerCount) {
+                  LOGGER.debug("Offset value has exceeded total hits");
+                  JsonObject response =
+                      new JsonObject()
+                          .put(TYPE, TYPE_SUCCESS)
+                          .put(TITLE, SUCCESS)
+                          .put(TOTAL_HITS, providerCount);
+                  handler.handle(Future.succeededFuture(response));
+                } else {
+                  endIndex = providerCount;
+                }
+              }
+              JsonArray pagedProviders = new JsonArray();
+              for (int i = requestParams.getInteger(OFFSET); i < endIndex; i++) {
+                pagedProviders.add(providersList.getJsonObject(i));
+              }
+              JsonObject response =
+                  new JsonObject()
+                      .put(TYPE, TYPE_SUCCESS)
+                      .put(TITLE, SUCCESS)
+                      .put(TOTAL_HITS, providerCount)
+                      .put(RESULTS, pagedProviders);
+              handler.handle(Future.succeededFuture(response));
+
+            } else {
+              LOGGER.error("Fail: failed DB request");
+              handler.handle(Future.failedFuture(internalErrorResp));
+            }
+          });
+    } else {
+      String query = GET_MLAYER_PROVIDERS_QUERY.replace("$0", limit).replace("$1", offset);
+      client.searchAsync(
+          query,
+          docIndex,
+          resultHandler -> {
+            if (resultHandler.succeeded()) {
+              LOGGER.debug("Success: Successful DB Request");
+              JsonObject result = resultHandler.result();
+              handler.handle(Future.succeededFuture(result));
+            } else {
+              LOGGER.error("Fail: failed DB request");
+              handler.handle(Future.failedFuture(internalErrorResp));
+            }
         });
+    }
   }
 }

--- a/src/test/resources/iudx-catalogue-server-v5.5.0.postman_collection.json
+++ b/src/test/resources/iudx-catalogue-server-v5.5.0.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "a3aec51e-fa8c-4852-8a0c-7a71104fb4c2",
+		"_postman_id": "adbf46da-9eae-4bd2-8cd3-e325de262a91",
 		"name": "iudx-catalogue-server v5.5.0",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "27217689"
@@ -14169,6 +14169,171 @@
 										"internal",
 										"ui",
 										"providers"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "200 (Success) - Get Providers with offset and limit",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Check response body\", function () {    \r",
+											"    const body = pm.response.json();\r",
+											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:cat:Success\");\r",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "",
+										"value": "",
+										"type": "text",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{host}}{{base}}/internal/ui/providers?offset=10&limit=3",
+									"host": [
+										"{{host}}{{base}}"
+									],
+									"path": [
+										"internal",
+										"ui",
+										"providers"
+									],
+									"query": [
+										{
+											"key": "offset",
+											"value": "10"
+										},
+										{
+											"key": "limit",
+											"value": "3"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "200 (Success) - Get Providers of an instance",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Check response body\", function () {    \r",
+											"    const body = pm.response.json();\r",
+											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:cat:Success\");\r",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "",
+										"value": "",
+										"type": "text",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{host}}{{base}}/internal/ui/providers?instance=pune",
+									"host": [
+										"{{host}}{{base}}"
+									],
+									"path": [
+										"internal",
+										"ui",
+										"providers"
+									],
+									"query": [
+										{
+											"key": "instance",
+											"value": "pune"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "200 (Success) - Get Providers with instance, offset and limit",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Response status\", function () {\r",
+											"    pm.response.to.have.status(200);\r",
+											"});\r",
+											"\r",
+											"pm.test(\"Check response body\", function () {    \r",
+											"    const body = pm.response.json();\r",
+											"    pm.expect(body).to.have.property(\"type\", \"urn:dx:cat:Success\");\r",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "",
+										"value": "",
+										"type": "text",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{host}}{{base}}/internal/ui/providers?instance=pune&offset=1&limit=1",
+									"host": [
+										"{{host}}{{base}}"
+									],
+									"path": [
+										"internal",
+										"ui",
+										"providers"
+									],
+									"query": [
+										{
+											"key": "instance",
+											"value": "pune"
+										},
+										{
+											"key": "offset",
+											"value": "1"
+										},
+										{
+											"key": "limit",
+											"value": "1"
+										}
 									]
 								}
 							},


### PR DESCRIPTION
In Mlayer Provider API, instance based filtration is added. 
The filtration process involves querying Resource Groups belonging to the "instance" and all Providers. Based on the "provider" field in resource group, providers are filtered from the list of all providers. This gives the provider belonging to a particular instance. Pagination is applied to final result. 