### PR TITLE
Fix: Concurrent Cancellation Exception

### DIFF
--- a/src/main/java/iudx/catalogue/server/database/DatabaseServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/database/DatabaseServiceImpl.java
@@ -6,6 +6,7 @@ import static iudx.catalogue.server.util.Constants.*;
 import io.vertx.core.*;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
 import iudx.catalogue.server.database.mlayer.*;
 import iudx.catalogue.server.geocoding.GeocodingService;
 import iudx.catalogue.server.nlpsearch.NLPSearchService;
@@ -45,6 +46,7 @@ public class DatabaseServiceImpl implements DatabaseService {
   private String ratingIndex;
   private String mlayerInstanceIndex;
   private String mlayerDomainIndex;
+  private WebClient webClient;
 
   /**
    * Constructs a new DatabaseServiceImpl instance with the given ElasticClient and index names.
@@ -56,12 +58,14 @@ public class DatabaseServiceImpl implements DatabaseService {
    * @param mlayerDomainIndex the name of the index used for ML layer domain storage
    */
   public DatabaseServiceImpl(
+      WebClient webClient,
       ElasticClient client,
       String docIndex,
       String ratingIndex,
       String mlayerInstanceIndex,
       String mlayerDomainIndex) {
     this(client);
+    this.webClient = webClient;
     this.docIndex = docIndex;
     this.ratingIndex = ratingIndex;
     this.mlayerInstanceIndex = mlayerInstanceIndex;
@@ -80,6 +84,7 @@ public class DatabaseServiceImpl implements DatabaseService {
    * @param geoService the geocoding service used to perform geocoding operations
    */
   public DatabaseServiceImpl(
+      WebClient webClient,
       ElasticClient client,
       String docIndex,
       String ratingIndex,
@@ -88,6 +93,7 @@ public class DatabaseServiceImpl implements DatabaseService {
       NLPSearchService nlpService,
       GeocodingService geoService) {
     this(client, nlpService, geoService);
+    this.webClient = webClient;
     this.docIndex = docIndex;
     this.ratingIndex = ratingIndex;
     this.mlayerInstanceIndex = mlayerInstanceIndex;
@@ -1356,7 +1362,8 @@ public class DatabaseServiceImpl implements DatabaseService {
   @Override
   public DatabaseService getMlayerAllDatasets(
       JsonObject requestParam, String query, Handler<AsyncResult<JsonObject>> handler) {
-    MlayerDataset mlayerDataset = new MlayerDataset(client, docIndex, mlayerInstanceIndex);
+    MlayerDataset mlayerDataset =
+        new MlayerDataset(webClient, client, docIndex, mlayerInstanceIndex);
     mlayerDataset.getMlayerAllDatasets(requestParam, query, handler);
     return this;
   }
@@ -1392,7 +1399,8 @@ public class DatabaseServiceImpl implements DatabaseService {
       return promise.future();
     }
 
-    String checkInstance = GET_INSTANCE_CASE_INSENSITIVE_QUERY.replace("$1", instanceId).replace("$2", "");
+    String checkInstance =
+        GET_INSTANCE_CASE_INSENSITIVE_QUERY.replace("$1", instanceId).replace("$2", "");
     client.searchAsync(
         checkInstance,
         docIndex,

--- a/src/main/java/iudx/catalogue/server/database/DatabaseVerticle.java
+++ b/src/main/java/iudx/catalogue/server/database/DatabaseVerticle.java
@@ -3,13 +3,15 @@ package iudx.catalogue.server.database;
 import static iudx.catalogue.server.util.Constants.*;
 
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.serviceproxy.ServiceBinder;
 import iudx.catalogue.server.geocoding.GeocodingService;
 import iudx.catalogue.server.nlpsearch.NLPSearchService;
-
 
 /**
  * The Database Verticle.
@@ -39,6 +41,17 @@ public class DatabaseVerticle extends AbstractVerticle {
   private MessageConsumer<JsonObject> consumer;
 
   /**
+   * Helper function to create a WebClient to talk to the vocabulary server.
+   *
+   * @param vertx the vertx instance
+   * @return a web client initialized with the relevant client certificate
+   */
+  static WebClient createWebClient(Vertx vertx) {
+    WebClientOptions webClientOptions = new WebClientOptions();
+    return WebClient.create(vertx, webClientOptions);
+  }
+
+  /**
    * This method is used to start the Verticle. It deploys a verticle in a cluster, registers the
    * service with the Event bus against an address, publishes the service with the service discovery
    * interface.
@@ -66,10 +79,22 @@ public class DatabaseVerticle extends AbstractVerticle {
       GeocodingService geoService = GeocodingService.createProxy(vertx, GEOCODING_SERVICE_ADDRESS);
       database =
           new DatabaseServiceImpl(
-              client, docIndex, ratingIndex, mlayerIndex, mlayerDomainIndex,
-                  nlpService, geoService);
+              createWebClient(vertx),
+              client,
+              docIndex,
+              ratingIndex,
+              mlayerIndex,
+              mlayerDomainIndex,
+              nlpService,
+              geoService);
     } else {
-      database = new DatabaseServiceImpl(client, docIndex, ratingIndex, mlayerIndex,
+      database =
+          new DatabaseServiceImpl(
+              createWebClient(vertx),
+              client,
+              docIndex,
+              ratingIndex,
+              mlayerIndex,
               mlayerDomainIndex);
     }
 

--- a/src/main/java/iudx/catalogue/server/database/mlayer/MlayerDataset.java
+++ b/src/main/java/iudx/catalogue/server/database/mlayer/MlayerDataset.java
@@ -8,6 +8,7 @@ import static iudx.catalogue.server.validator.Constants.VALIDATION_FAILURE_MSG;
 import io.vertx.core.*;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
 import iudx.catalogue.server.database.ElasticClient;
 import iudx.catalogue.server.database.RespBuilder;
 import iudx.catalogue.server.database.Util;
@@ -26,8 +27,17 @@ public class MlayerDataset {
           .withDetail(DETAIL_INTERNAL_SERVER_ERROR)
           .getResponse();
   ElasticClient client;
+  WebClient webClient;
   String docIndex;
   String mlayerInstanceIndex;
+
+  public MlayerDataset(
+      WebClient webClient, ElasticClient client, String docIndex, String mlayerInstanceIndex) {
+    this.webClient = webClient;
+    this.client = client;
+    this.docIndex = docIndex;
+    this.mlayerInstanceIndex = mlayerInstanceIndex;
+  }
 
   public MlayerDataset(ElasticClient client, String docIndex, String mlayerInstanceIndex) {
     this.client = client;
@@ -137,9 +147,7 @@ public class MlayerDataset {
   }
 
   public void getMlayerAllDatasets(
-      JsonObject requestParam,
-      String query,
-      Handler<AsyncResult<JsonObject>> handler) {
+      JsonObject requestParam, String query, Handler<AsyncResult<JsonObject>> handler) {
 
     LOGGER.debug("Getting all the resource group items");
     Promise<JsonObject> datasetResult = Promise.promise();
@@ -154,7 +162,7 @@ public class MlayerDataset {
         .onComplete(
             ar -> {
               if (ar.succeeded()) {
-                DataModel dataModel = new DataModel(client, docIndex);
+                DataModel dataModel = new DataModel(webClient, client, docIndex);
                 dataModel
                     .getDataModelInfo()
                     .onComplete(
@@ -264,8 +272,7 @@ public class MlayerDataset {
               int size = resultHandler.result().getJsonArray(RESULTS).size();
               if (size == 0) {
                 LOGGER.debug("getRGs is zero");
-                datasetResult.handle(
-                    Future.failedFuture(NO_CONTENT_AVAILABLE));
+                datasetResult.handle(Future.failedFuture(NO_CONTENT_AVAILABLE));
                 return;
               }
               JsonObject rsUrl = new JsonObject();

--- a/src/main/java/iudx/catalogue/server/database/mlayer/MlayerDataset.java
+++ b/src/main/java/iudx/catalogue/server/database/mlayer/MlayerDataset.java
@@ -162,8 +162,8 @@ public class MlayerDataset {
         .onComplete(
             ar -> {
               if (ar.succeeded()) {
-                DataModel dataModel = new DataModel(webClient, client, docIndex);
-                dataModel
+                DataModel domainInfoFetcher = new DataModel(webClient, client, docIndex);
+                domainInfoFetcher
                     .getDataModelInfo()
                     .onComplete(
                         domainInfoResult -> {

--- a/src/main/java/iudx/catalogue/server/mlayer/vocabulary/DataModel.java
+++ b/src/main/java/iudx/catalogue/server/mlayer/vocabulary/DataModel.java
@@ -127,7 +127,10 @@ public class DataModel {
     }
 
     AtomicInteger pendingRequests = new AtomicInteger(uniqueClassIds.size());
-
+    if (uniqueClassIds.isEmpty()) {
+      promise.complete(idToSubClassMap);
+      return promise.future();
+    }
     for (String classId : uniqueClassIds) {
       String dmUrl = contextUrl + classId + ".jsonld";
       acquireSemaphoreAndFetchDataModel(
@@ -180,7 +183,7 @@ public class DataModel {
    * @param promise The Promise to complete with idToSubClassMap.
    * @param dmUrl The URL of the data model.
    */
-  private void handleDataModelResponse(
+  void handleDataModelResponse(
       AsyncResult<HttpResponse<Buffer>> dmAr,
       String classId,
       Map<String, String> idToClassIdMap,

--- a/src/main/java/iudx/catalogue/server/mlayer/vocabulary/DataModel.java
+++ b/src/main/java/iudx/catalogue/server/mlayer/vocabulary/DataModel.java
@@ -5,14 +5,16 @@ import static iudx.catalogue.server.database.Constants.GET_ALL_DATASETS_BY_RS_GR
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.client.WebClientOptions;
 import iudx.catalogue.server.database.ElasticClient;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
@@ -32,12 +34,8 @@ public class DataModel {
    * @param client The ElasticClient instance
    * @param docIndex The index name where data are stored/retrieved in elastic.
    */
-  public DataModel(ElasticClient client, String docIndex) {
-    WebClientOptions options = new WebClientOptions()
-            .setMaxPoolSize(10)
-            .setKeepAlive(true)
-            .setConnectTimeout(5000);
-    this.webClient = WebClient.create(Vertx.vertx(), options);
+  public DataModel(WebClient webClient, ElasticClient client, String docIndex) {
+    this.webClient = webClient;
     this.client = client;
     this.docIndex = docIndex;
   }
@@ -98,48 +96,52 @@ public class DataModel {
    * Fetches data models asynchronously.
    *
    * @param results The JsonArray of results from Elasticsearch search.
-   * @return Future containing JsonObject with class to subclass mappings.
+   * @return Future containing JsonObject with id to subclass mappings.
    */
   private Future<JsonObject> fetchDataModels(JsonArray results) {
     Promise<JsonObject> promise = Promise.promise();
-    JsonObject classIdToSubClassMap = new JsonObject();
+    JsonObject idToSubClassMap = new JsonObject();
 
     if (results.isEmpty()) {
-      promise.complete(classIdToSubClassMap);
+      promise.complete(idToSubClassMap);
       return promise.future();
     }
 
-    AtomicInteger pendingRequests = new AtomicInteger(results.size());
+    Set<String> uniqueClassIds = new HashSet<>();
     String contextUrl = results.getJsonObject(0).getString("@context");
-
+    Map<String, String> idToClassIdMap = new HashMap<>();
     for (int i = 0; i < results.size(); i++) {
       JsonObject result = results.getJsonObject(i);
+      String id = result.getString("id");
       JsonArray typeArray = result.getJsonArray("type");
 
       if (typeArray == null || typeArray.size() < 2) {
         LOGGER.error("Invalid type array in result: {}", result.encode());
-        if (pendingRequests.decrementAndGet() == 0) {
-          promise.complete(classIdToSubClassMap);
-        }
         continue;
       }
 
-      String id = result.getString("id");
       String type = typeArray.getString(1);
       String classId = type.split(":")[1];
-      String dmUrl = contextUrl + classId + ".jsonld";
-
-      acquireSemaphoreAndFetchDataModel(
-          id, classId, dmUrl, classIdToSubClassMap, pendingRequests, promise);
+      uniqueClassIds.add(classId);
+      idToClassIdMap.put(id, classId);
     }
+
+    AtomicInteger pendingRequests = new AtomicInteger(uniqueClassIds.size());
+
+    for (String classId : uniqueClassIds) {
+      String dmUrl = contextUrl + classId + ".jsonld";
+      acquireSemaphoreAndFetchDataModel(
+          classId, dmUrl, idToClassIdMap, idToSubClassMap, pendingRequests, promise);
+    }
+
     return promise.future();
   }
 
   private void acquireSemaphoreAndFetchDataModel(
-      String id,
       String classId,
       String dmUrl,
-      JsonObject classIdToSubClassMap,
+      Map<String, String> idToClassIdMap,
+      JsonObject idToSubClassMap,
       AtomicInteger pendingRequests,
       Promise<JsonObject> promise) {
     try {
@@ -149,14 +151,20 @@ public class DataModel {
           .send(
               dmAr -> {
                 handleDataModelResponse(
-                    dmAr, id, classId, classIdToSubClassMap, pendingRequests, promise, dmUrl);
+                    dmAr,
+                    classId,
+                    idToClassIdMap,
+                    idToSubClassMap,
+                    pendingRequests,
+                    promise,
+                    dmUrl);
                 semaphore.release();
               });
     } catch (InterruptedException e) {
       LOGGER.error("Semaphore acquisition interrupted for URL: {}", dmUrl, e);
       semaphore.release();
       if (pendingRequests.decrementAndGet() == 0) {
-        promise.complete(classIdToSubClassMap);
+        promise.complete(idToSubClassMap);
       }
     }
   }
@@ -165,18 +173,18 @@ public class DataModel {
    * Handles the response from fetching data model information.
    *
    * @param dmAr The async result of the HTTP response.
-   * @param id The id of the data model.
    * @param classId The class id of the data model.
-   * @param classIdToSubClassMap The JsonObject mapping class to subclass.
+   * @param idToClassIdMap The map of id to classId.
+   * @param idToSubClassMap The JsonObject mapping id to subclass.
    * @param pendingRequests The AtomicInteger tracking pending requests.
-   * @param promise The Promise to complete with classIdToSubClassMap.
+   * @param promise The Promise to complete with idToSubClassMap.
    * @param dmUrl The URL of the data model.
    */
   private void handleDataModelResponse(
       AsyncResult<HttpResponse<Buffer>> dmAr,
-      String id,
       String classId,
-      JsonObject classIdToSubClassMap,
+      Map<String, String> idToClassIdMap,
+      JsonObject idToSubClassMap,
       AtomicInteger pendingRequests,
       Promise<JsonObject> promise,
       String dmUrl) {
@@ -210,7 +218,11 @@ public class DataModel {
                     String subClassIdStr = subClassOfObj.getString("@id");
                     if (subClassIdStr != null && subClassIdStr.contains(":")) {
                       String subClassId = subClassIdStr.split(":")[1];
-                      classIdToSubClassMap.put(id, subClassId);
+                      for (Map.Entry<String, String> entry : idToClassIdMap.entrySet()) {
+                        if (entry.getValue().equals(classId)) {
+                          idToSubClassMap.put(entry.getKey(), subClassId);
+                        }
+                      }
                     } else {
                       LOGGER.error("Invalid @id in rdfs:subClassOf for class ID: {}", classId);
                     }
@@ -231,7 +243,7 @@ public class DataModel {
     }
 
     if (pendingRequests.decrementAndGet() == 0) {
-      promise.complete(classIdToSubClassMap);
+      promise.complete(idToSubClassMap);
     }
   }
 }

--- a/src/test/java/iudx/catalogue/server/apiserver/integrationtests/crudApisIT/CrudAPIsIT.java
+++ b/src/test/java/iudx/catalogue/server/apiserver/integrationtests/crudApisIT/CrudAPIsIT.java
@@ -558,7 +558,7 @@ public class CrudAPIsIT {
                                 )
                         )
                 )
-                .put("resourceServerRegURL", "rs.iudx.io")
+                .put("resourceServerRegURL", "rs-test-pm.iudx.io")
                 .put("resourceAccessModalities", new JsonArray()
                         .add(new JsonObject()
                                 .put("type", new JsonArray().add("iudx:HTTPAccess"))

--- a/src/test/java/iudx/catalogue/server/database/DatabaseServiceImplTest.java
+++ b/src/test/java/iudx/catalogue/server/database/DatabaseServiceImplTest.java
@@ -15,6 +15,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import iudx.catalogue.server.Configuration;
 import iudx.catalogue.server.geocoding.GeocodingService;
+import iudx.catalogue.server.mlayer.vocabulary.DataModel;
 import iudx.catalogue.server.nlpsearch.NLPSearchService;
 import java.util.List;
 import java.util.function.Consumer;
@@ -2384,6 +2385,7 @@ public class DatabaseServiceImplTest {
               @Override
               public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
                 ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
+                testContext.completeNow();
                 return null;
               }
             })
@@ -2398,7 +2400,6 @@ public class DatabaseServiceImplTest {
             verify(client, times(6)).searchAsync(any(), any(), any());
             verify(client, times(1)).resourceAggregationAsync(any(), any(), any());
             testContext.completeNow();
-
           } else {
             testContext.failNow("fail");
           }
@@ -2509,6 +2510,7 @@ public class DatabaseServiceImplTest {
               @Override
               public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
                 ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
+                testContext.completeNow();
                 return null;
               }
             })

--- a/src/test/java/iudx/catalogue/server/database/DatabaseServiceImplTest.java
+++ b/src/test/java/iudx/catalogue/server/database/DatabaseServiceImplTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.*;
 import io.vertx.core.*;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import iudx.catalogue.server.Configuration;
@@ -35,6 +36,7 @@ import org.mockito.stubbing.Answer;
 public class DatabaseServiceImplTest {
   private static final Logger LOGGER = LogManager.getLogger(DatabaseServiceTest.class);
   static AsyncResult<JsonObject> asyncResult;
+  @Mock static WebClient webClient;
   private static DatabaseService dbService;
   private static Vertx vertxObj;
   private static ElasticClient client;
@@ -81,6 +83,7 @@ public class DatabaseServiceImplTest {
       GeocodingService geoService = GeocodingService.createProxy(vertx, GEOCODING_SERVICE_ADDRESS);
       dbService =
           new DatabaseServiceImpl(
+              webClient,
               client,
               docIndex,
               ratingIndex,
@@ -91,7 +94,7 @@ public class DatabaseServiceImplTest {
     } else {
       dbService =
           new DatabaseServiceImpl(
-              client, docIndex, ratingIndex, mlayerInstanceIndex, mlayerDomainIndex);
+              webClient, client, docIndex, ratingIndex, mlayerInstanceIndex, mlayerDomainIndex);
     }
 
     testContext.completeNow();
@@ -101,68 +104,68 @@ public class DatabaseServiceImplTest {
   @DisplayName("initialize mocks")
   public static void initializeMocks(VertxTestContext testContext) {
     doAnswer(
-        new Answer<AsyncResult<JsonObject>>() {
-          @Override
-          public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-            ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(asyncResult);
-            return null;
-          }
-        })
+            new Answer<AsyncResult<JsonObject>>() {
+              @Override
+              public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+                ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(asyncResult);
+                return null;
+              }
+            })
         .when(client)
         .scriptSearch(any(), any());
 
     doAnswer(
-        new Answer<AsyncResult<JsonObject>>() {
-          @Override
-          public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-            ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
-            return null;
-          }
-        })
+            new Answer<AsyncResult<JsonObject>>() {
+              @Override
+              public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+                ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
+                return null;
+              }
+            })
         .when(client)
         .searchAsync(any(), any(), any());
 
     doAnswer(
-        new Answer<AsyncResult<JsonObject>>() {
-          @Override
-          public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-            ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(asyncResult);
-            return null;
-          }
-        })
+            new Answer<AsyncResult<JsonObject>>() {
+              @Override
+              public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+                ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(1)).handle(asyncResult);
+                return null;
+              }
+            })
         .when(client)
         .listAggregationAsync(any(), any());
 
     doAnswer(
-        new Answer<AsyncResult<JsonObject>>() {
-          @Override
-          public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-            ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
-            return null;
-          }
-        })
+            new Answer<AsyncResult<JsonObject>>() {
+              @Override
+              public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+                ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
+                return null;
+              }
+            })
         .when(client)
         .countAsync(any(), any(), any());
 
     doAnswer(
-        new Answer<AsyncResult<JsonObject>>() {
-          @Override
-          public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-            ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
-            return null;
-          }
-        })
+            new Answer<AsyncResult<JsonObject>>() {
+              @Override
+              public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+                ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
+                return null;
+              }
+            })
         .when(client)
         .searchGetId(any(), any(), any());
 
     doAnswer(
-        new Answer<AsyncResult<JsonObject>>() {
-          @Override
-          public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-            ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
-            return null;
-          }
-        })
+            new Answer<AsyncResult<JsonObject>>() {
+              @Override
+              public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+                ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
+                return null;
+              }
+            })
         .when(client)
         .searchAsyncGetId(any(), any(), any());
 
@@ -218,9 +221,7 @@ public class DatabaseServiceImplTest {
     JsonArray jsonArray = new JsonArray().add(new JsonObject().put("country", "India"));
     JsonObject jo = new JsonObject().put(RESULTS, jsonArray);
     request.add(0, jsonArray);
-    doAnswer(Answer -> Future.succeededFuture(jo))
-        .when(client)
-        .scriptLocationSearch(any(), any());
+    doAnswer(Answer -> Future.succeededFuture(jo)).when(client).scriptLocationSearch(any(), any());
 
     dbService.nlpSearchLocationQuery(
         request,
@@ -364,7 +365,7 @@ public class DatabaseServiceImplTest {
         handler -> {
           if (handler.failed()) {
             assertTrue(handler.cause().getMessage().contains(TYPE_INTERNAL_SERVER_ERROR));
-//            verify(client, times(47)).searchAsync(anyString(),anyString(), any());
+            //            verify(client, times(47)).searchAsync(anyString(),anyString(), any());
             vertxTestContext.completeNow();
           } else {
             vertxTestContext.failNow("Fail");
@@ -386,7 +387,7 @@ public class DatabaseServiceImplTest {
   public void testVerifyInstanceFailed(VertxTestContext vertxTestContext) {
     DatabaseServiceImpl databaseService =
         new DatabaseServiceImpl(
-            client, docIndex, ratingIndex, mlayerInstanceIndex, mlayerDomainIndex);
+            webClient, client, docIndex, ratingIndex, mlayerInstanceIndex, mlayerDomainIndex);
     String instanceId = "dummy";
     when(asyncResult.failed()).thenReturn(true);
     when(asyncResult.cause()).thenReturn(throwable);
@@ -412,12 +413,11 @@ public class DatabaseServiceImplTest {
   public void testVerifyInstance0Hits(VertxTestContext vertxTestContext) {
     DatabaseServiceImpl databaseService =
         new DatabaseServiceImpl(
-            client, docIndex, ratingIndex, mlayerInstanceIndex, mlayerDomainIndex);
+            webClient, client, docIndex, ratingIndex, mlayerInstanceIndex, mlayerDomainIndex);
     String instanceId = "dummy";
     JsonObject json = new JsonObject();
     json.put(TOTAL_HITS, 0);
     when(asyncResult.result()).thenReturn(json);
-
 
     databaseService
         .verifyInstance(instanceId)
@@ -438,7 +438,7 @@ public class DatabaseServiceImplTest {
   public void testVerifyInstance(VertxTestContext vertxTestContext) {
     DatabaseServiceImpl databaseService =
         new DatabaseServiceImpl(
-            client, docIndex, ratingIndex, mlayerInstanceIndex, mlayerDomainIndex);
+            webClient, client, docIndex, ratingIndex, mlayerInstanceIndex, mlayerDomainIndex);
     String instanceId = "dummy";
     JsonObject json = new JsonObject();
     json.put(TOTAL_HITS, 100);
@@ -521,7 +521,7 @@ public class DatabaseServiceImplTest {
         handler -> {
           if (handler.failed()) {
             verify(client, times(1)).docPostAsync(any(), any(), any());
-//            verify(client, times(9)).searchAsync(any(), any(), any());
+            //            verify(client, times(9)).searchAsync(any(), any(), any());
             vertxTestContext.completeNow();
           } else {
             vertxTestContext.failNow("Fail");
@@ -563,8 +563,7 @@ public class DatabaseServiceImplTest {
         json,
         handler -> {
           if (handler.succeeded()) {
-            verify(client, times(2))
-                .ratingAggregationAsync(any(), any(), any());
+            verify(client, times(2)).ratingAggregationAsync(any(), any(), any());
             vertxTestContext.completeNow();
           } else {
             vertxTestContext.failNow("Fail");
@@ -603,7 +602,6 @@ public class DatabaseServiceImplTest {
     when(asyncResult.failed()).thenReturn(true);
     when(asyncResult.cause()).thenReturn(throwable);
 
-
     dbService.createItem(
         json,
         handler -> {
@@ -635,7 +633,6 @@ public class DatabaseServiceImplTest {
     json.put(RELATIONSHIP, jsonArray).put(VALUE, jsonArray2);
     when(asyncResult.succeeded()).thenReturn(true);
     when(asyncResult.result()).thenReturn(jsonObject);
-
 
     dbService.relSearch(
         json,
@@ -686,7 +683,6 @@ public class DatabaseServiceImplTest {
     when(asyncResult.cause()).thenReturn(throwable);
     when(throwable.getMessage()).thenReturn("dummy");
 
-
     dbService.relSearch(
         json,
         handler -> {
@@ -708,7 +704,6 @@ public class DatabaseServiceImplTest {
     json.put(TOTAL_HITS, 0);
     when(asyncResult.failed()).thenReturn(true);
     when(asyncResult.cause()).thenReturn(throwable);
-
 
     dbService.deleteRating(
         json,
@@ -735,8 +730,6 @@ public class DatabaseServiceImplTest {
     when(asyncResult.succeeded()).thenReturn(true);
     when(asyncResult.result()).thenReturn(json);
     when(asyncResult.cause()).thenReturn(throwable);
-
-
 
     AsyncResult<JsonObject> asyncResult1 = mock(AsyncResult.class);
     when(asyncResult1.succeeded()).thenReturn(false);
@@ -790,8 +783,6 @@ public class DatabaseServiceImplTest {
         .when(client)
         .docPutAsync(any(), any(), any(), any());
 
-
-
     dbService.updateRating(
         json,
         handler -> {
@@ -817,8 +808,6 @@ public class DatabaseServiceImplTest {
     json.put(TOTAL_HITS, 1);
     when(asyncResult.succeeded()).thenReturn(false);
     when(asyncResult.cause()).thenReturn(throwable);
-
-
 
     dbService.getRatings(
         json,
@@ -1093,7 +1082,11 @@ public class DatabaseServiceImplTest {
   @Description("test listRelationship method when item is resource")
   public void testListRelationshipResourceGroup(VertxTestContext vertxTestContext) {
     JsonArray typeArray = new JsonArray().add("iudx:ResourceGroup");
-    JsonObject jsonObject = new JsonObject().put(TYPE, typeArray).put("resourceGroup", "dummy id").put("provider", "provider-id");
+    JsonObject jsonObject =
+        new JsonObject()
+            .put(TYPE, typeArray)
+            .put("resourceGroup", "dummy id")
+            .put("provider", "provider-id");
     JsonArray resultArray = new JsonArray().add(jsonObject);
     JsonObject json =
         new JsonObject()
@@ -1193,8 +1186,7 @@ public class DatabaseServiceImplTest {
         json,
         handler -> {
           if (handler.failed()) {
-            verify(client, times(1))
-                .ratingAggregationAsync(any(), any(), any());
+            verify(client, times(1)).ratingAggregationAsync(any(), any(), any());
             vertxTestContext.completeNow();
           } else {
             vertxTestContext.failNow("Fail");
@@ -1207,6 +1199,7 @@ public class DatabaseServiceImplTest {
   public void testCreateItemFailed(VertxTestContext vertxTestContext) {
     DatabaseServiceImpl databaseService =
         new DatabaseServiceImpl(
+            webClient,
             client,
             docIndex,
             ratingIndex,
@@ -1221,7 +1214,6 @@ public class DatabaseServiceImplTest {
     when(asyncResult.failed()).thenReturn(true);
     when(asyncResult.cause()).thenReturn(throwable);
     when(throwable.getMessage()).thenReturn("dummy");
-
 
     dbService.createItem(json, handler);
     databaseService
@@ -1242,6 +1234,7 @@ public class DatabaseServiceImplTest {
   public void testCreateItemSucceeded(VertxTestContext vertxTestContext) {
     DatabaseServiceImpl databaseService =
         new DatabaseServiceImpl(
+            webClient,
             client,
             docIndex,
             ratingIndex,
@@ -1275,6 +1268,7 @@ public class DatabaseServiceImplTest {
   public void testCreateItemHits0(VertxTestContext vertxTestContext) {
     DatabaseServiceImpl databaseService =
         new DatabaseServiceImpl(
+            webClient,
             client,
             docIndex,
             ratingIndex,
@@ -1288,8 +1282,6 @@ public class DatabaseServiceImplTest {
     String instanceId = "pune";
     when(asyncResult.failed()).thenReturn(false);
     when(asyncResult.result()).thenReturn(json);
-
-
 
     dbService.createItem(json, handler);
     databaseService
@@ -1420,46 +1412,50 @@ public class DatabaseServiceImplTest {
         });
   }
 
-//  @Test
-//  @Description("test getMlayerInstance method when the DB Request is Successful")
-//  public void testGetMlayerInstance(VertxTestContext testContext) {
-//
-//    when(asyncResult.succeeded()).thenReturn(true);
-//
-//    dbService.getMlayerInstance("id",
-//        handler -> {
-//          if (handler.succeeded()) {
-//            verify(client, times(34)).searchAsync(any(), any(), any());
-//            testContext.completeNow();
-//          } else {
-//            testContext.failNow("Fail");
-//          }
-//        });
-//  }
-@Test
-@Description("test getMlayerInstance method when the DB Request is Successful")
-public void testGetMlayerInstance(VertxTestContext testContext) {
-    JsonObject requestParams = new JsonObject().put("id", ID).put("limit", LIMIT).put("offset",OFFSET);
+  //  @Test
+  //  @Description("test getMlayerInstance method when the DB Request is Successful")
+  //  public void testGetMlayerInstance(VertxTestContext testContext) {
+  //
+  //    when(asyncResult.succeeded()).thenReturn(true);
+  //
+  //    dbService.getMlayerInstance("id",
+  //        handler -> {
+  //          if (handler.succeeded()) {
+  //            verify(client, times(34)).searchAsync(any(), any(), any());
+  //            testContext.completeNow();
+  //          } else {
+  //            testContext.failNow("Fail");
+  //          }
+  //        });
+  //  }
+  @Test
+  @Description("test getMlayerInstance method when the DB Request is Successful")
+  public void testGetMlayerInstance(VertxTestContext testContext) {
+    JsonObject requestParams =
+        new JsonObject().put("id", ID).put("limit", LIMIT).put("offset", OFFSET);
     when(asyncResult.succeeded()).thenReturn(true);
 
-//    when(asyncResult.succeeded()).thenReturn(true);
-    dbService.getMlayerInstance(requestParams,
-            handler -> {
-                if (handler.succeeded()) {
-                    verify(client, times(35)).searchAsync(any(), any(), any());
-                    testContext.completeNow();
-                } else {
-                    testContext.failNow("Fail");
-                }
-            });
-}
+    //    when(asyncResult.succeeded()).thenReturn(true);
+    dbService.getMlayerInstance(
+        requestParams,
+        handler -> {
+          if (handler.succeeded()) {
+            verify(client, times(35)).searchAsync(any(), any(), any());
+            testContext.completeNow();
+          } else {
+            testContext.failNow("Fail");
+          }
+        });
+  }
 
   @Test
   @Description("test getMlayerInstance method when get instance DB Request fails")
   public void testGetMlayerInstanceFailure(VertxTestContext testContext) {
-      JsonObject requestParams = new JsonObject().put("id", ID).put("limit", LIMIT).put("offset",OFFSET);
+    JsonObject requestParams =
+        new JsonObject().put("id", ID).put("limit", LIMIT).put("offset", OFFSET);
     when(asyncResult.succeeded()).thenReturn(false);
-    dbService.getMlayerInstance(requestParams,
+    dbService.getMlayerInstance(
+        requestParams,
         handler -> {
           if (handler.failed()) {
             verify(client, times(64)).searchAsync(any(), any(), any());
@@ -1615,7 +1611,6 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
     when(asyncResult.failed()).thenReturn(false);
     when(asyncResult.result()).thenReturn(json);
 
-
     dbService.updateMlayerInstance(
         json,
         handler -> {
@@ -1646,7 +1641,6 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
         .put(MLAYER_ID, "id")
         .put("name", "domain-name");
     when(asyncResult.result()).thenReturn(json);
-
 
     dbService.updateMlayerInstance(
         json,
@@ -1822,7 +1816,6 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
     when(asyncResult.failed()).thenReturn(true);
     request.put(DOMAIN_ID, "dummy").put(MLAYER_ID, "dummy");
 
-
     dbService.createMlayerDomain(
         request,
         handler -> {
@@ -1864,12 +1857,14 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
   @Test
   @Description("test getMlayerDomain method when the DB Request is Successful")
   public void testGetMlayerDomain(VertxTestContext testContext) {
-      JsonObject requestParams = new JsonObject().put("id", ID).put("limit", LIMIT).put("offset",OFFSET);
+    JsonObject requestParams =
+        new JsonObject().put("id", ID).put("limit", LIMIT).put("offset", OFFSET);
 
     when(asyncResult.succeeded()).thenReturn(true);
 
     dbService.getMlayerDomain(
-       requestParams, handler -> {
+        requestParams,
+        handler -> {
           if (handler.succeeded()) {
             verify(client, times(38)).searchAsync(any(), any(), any());
             testContext.completeNow();
@@ -1882,11 +1877,13 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
   @Test
   @Description("test getMlayerDomain method when get instance DB Request fails")
   public void testGetMlayerDomainFailure(VertxTestContext testContext) {
-      JsonObject requestParams = new JsonObject().put("id", ID).put("limit", LIMIT).put("offset",OFFSET);
+    JsonObject requestParams =
+        new JsonObject().put("id", ID).put("limit", LIMIT).put("offset", OFFSET);
     when(asyncResult.succeeded()).thenReturn(false);
 
     dbService.getMlayerDomain(
-       requestParams, handler -> {
+        requestParams,
+        handler -> {
           if (handler.failed()) {
             verify(client, times(59)).searchAsync(any(), any(), any());
             testContext.completeNow();
@@ -2041,7 +2038,6 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
     when(asyncResult.failed()).thenReturn(false);
     when(asyncResult.result()).thenReturn(json);
 
-
     dbService.updateMlayerDomain(
         json,
         handler -> {
@@ -2117,7 +2113,6 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
         .put("name", "domain-name");
     when(asyncResult.result()).thenReturn(json);
 
-
     dbService.updateMlayerDomain(
         json,
         handler -> {
@@ -2175,11 +2170,13 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
   @Test
   @Description("test getMlayerProviders method when the DB Request is Successful")
   public void testGetMlayerProviders(VertxTestContext testContext) {
-      JsonObject requestParams = new JsonObject().put("id", ID).put("limit", LIMIT).put("offset",OFFSET);
+    JsonObject requestParams =
+        new JsonObject().put("id", ID).put("limit", LIMIT).put("offset", OFFSET);
 
     when(asyncResult.succeeded()).thenReturn(true);
 
-    dbService.getMlayerProviders(requestParams,
+    dbService.getMlayerProviders(
+        requestParams,
         handler -> {
           if (handler.succeeded()) {
             verify(client, times(25)).searchAsync(any(), any(), any());
@@ -2193,10 +2190,12 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
   @Test
   @Description("test getMlayerProviders method when get providers DB Request fails")
   public void testGetMlayerProvidersFailure(VertxTestContext testContext) {
-      JsonObject requestParams = new JsonObject().put("id", ID).put("limit", LIMIT).put("offset",OFFSET);
+    JsonObject requestParams =
+        new JsonObject().put("id", ID).put("limit", LIMIT).put("offset", OFFSET);
     when(asyncResult.succeeded()).thenReturn(false);
 
-    dbService.getMlayerProviders(requestParams,
+    dbService.getMlayerProviders(
+        requestParams,
         handler -> {
           if (handler.failed()) {
             verify(client, times(46)).searchAsync(any(), any(), any());
@@ -2239,130 +2238,117 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
         });
   }
 
+  @Test
+  @Description("test getMlayerDataset method when DB Request has 0 hits")
+  public void testGetMlayerDataset0Hits(VertxTestContext testContext) {
+    JsonArray results = new JsonArray();
+    JsonObject provider = new JsonObject().put("provider", "dummy id");
+    results.add(0, provider);
+    JsonObject request = new JsonObject().put(TOTAL_HITS, 0).put(ID, "dummy").put(RESULTS, results);
+    when(asyncResult.succeeded()).thenReturn(true);
+    when(asyncResult.result()).thenReturn(request);
 
-    @Test
-    @Description("test getMlayerDataset method when DB Request has 0 hits")
-    public void testGetMlayerDataset0Hits(VertxTestContext testContext) {
-        JsonArray results = new JsonArray();
-        JsonObject provider = new JsonObject()
-                .put("provider", "dummy id");
-        results.add(0, provider);
-        JsonObject request = new JsonObject()
-                .put(TOTAL_HITS, 0)
-                .put(ID, "dummy")
-                .put(RESULTS, results);
-        when(asyncResult.succeeded()).thenReturn(true);
-        when(asyncResult.result()).thenReturn(request);
-
-        dbService.getMlayerDataset(
-                request,
-                handler -> {
-                    if (handler.succeeded()) {
-                        verify(client, times(2)).searchAsync(any(), any(), any());
-                        testContext.failNow("fail");
-
-
-                    } else {
-                        testContext.completeNow();
-                    }
-                });
-    }
-
-    @Test
-    @Description("test getMlayerDataset method when DB Request is successful")
-    public void testGetMlayerDatasetSuccess(VertxTestContext testContext) {
-        JsonArray results = new JsonArray();
-        JsonObject json = new JsonObject()
-                .put("instance", "pune");
-        JsonArray jsonArray = new JsonArray();
-        JsonObject provider = new JsonObject()
-                .put("provider", "dummy id")
-                .put("cos", "cis id")
-                .put("dataset", json)
-                .put("resource", jsonArray);
-        results.add(0, provider);
-        JsonObject request = new JsonObject()
-                .put(TOTAL_HITS, 50)
-                .put(ID, "dummy")
-                .put(RESULTS, results);
-        when(asyncResult.succeeded()).thenReturn(true);
-        when(asyncResult.result()).thenReturn(request);
-        doAnswer(
-                new Answer<AsyncResult<JsonObject>>() {
-                    @Override
-                    public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-                        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
-                        return null;
-                    }
-                })
-                .when(client)
-                .searchAsyncDataset(any(), any(), any());
-
-        dbService.getMlayerDataset(
-                request,
-                handler -> {
-                    if (handler.succeeded()) {
-                        verify(client, times(52)).searchAsync(any(), any(), any());
-                        verify(client, times(2)).searchAsyncDataset(any(), any(), any());
-
-                        testContext.completeNow();
+    dbService.getMlayerDataset(
+        request,
+        handler -> {
+          if (handler.succeeded()) {
+            verify(client, times(2)).searchAsync(any(), any(), any());
+            testContext.failNow("fail");
 
           } else {
-              testContext.failNow("fail");
+            testContext.completeNow();
           }
         });
   }
 
-    @Test
-    @Description("test getMlayerDataset method when DB Request is fails")
-    public void testGetMlayerDatasetFailure(VertxTestContext testContext) {
-        JsonArray results = new JsonArray();
-        JsonObject json = new JsonObject()
-                .put("instance", "pune");
-        JsonArray jsonArray = new JsonArray();
-        JsonObject provider = new JsonObject()
-                .put("provider", "dummy id")
-                .put("cos", "cis id")
-                .put("dataset", json)
-                .put("resource", jsonArray);
-        results.add(0, provider);
-        JsonObject request = new JsonObject()
-                .put(TOTAL_HITS, 50)
-                .put(ID, "dummy")
-                .put(RESULTS, results);
-        when(asyncResult.succeeded()).thenReturn(false);
-        when(asyncResult.result()).thenReturn(request);
-        doAnswer(
-                new Answer<AsyncResult<JsonObject>>() {
-                    @Override
-                    public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-                        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
-                        return null;
-                    }
-                })
-                .when(client)
-                .searchAsyncDataset(any(), any(), any());
+  @Test
+  @Description("test getMlayerDataset method when DB Request is successful")
+  public void testGetMlayerDatasetSuccess(VertxTestContext testContext) {
+    JsonArray results = new JsonArray();
+    JsonObject json = new JsonObject().put("instance", "pune");
+    JsonArray jsonArray = new JsonArray();
+    JsonObject provider =
+        new JsonObject()
+            .put("provider", "dummy id")
+            .put("cos", "cis id")
+            .put("dataset", json)
+            .put("resource", jsonArray);
+    results.add(0, provider);
+    JsonObject request =
+        new JsonObject().put(TOTAL_HITS, 50).put(ID, "dummy").put(RESULTS, results);
+    when(asyncResult.succeeded()).thenReturn(true);
+    when(asyncResult.result()).thenReturn(request);
+    doAnswer(
+            new Answer<AsyncResult<JsonObject>>() {
+              @Override
+              public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+                ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
+                return null;
+              }
+            })
+        .when(client)
+        .searchAsyncDataset(any(), any(), any());
 
-        dbService.getMlayerDataset(
-                request,
-                handler -> {
-                    if (handler.succeeded()) {
-                        testContext.failNow("fail");
+    dbService.getMlayerDataset(
+        request,
+        handler -> {
+          if (handler.succeeded()) {
+            verify(client, times(52)).searchAsync(any(), any(), any());
+            verify(client, times(2)).searchAsyncDataset(any(), any(), any());
 
+            testContext.completeNow();
 
-                    } else {
-                        verify(client, times(67)).searchAsync(any(), any(), any());
-                        verify(client, times(2)).searchAsyncDataset(any(), any(), any());
-
-                        testContext.completeNow();
-                    }
-                });
-    }
-
+          } else {
+            testContext.failNow("fail");
+          }
+        });
+  }
 
   @Test
-  @Description(
-      "test getMlayerAllDatasets method when DB Request is successful")
+  @Description("test getMlayerDataset method when DB Request is fails")
+  public void testGetMlayerDatasetFailure(VertxTestContext testContext) {
+    JsonArray results = new JsonArray();
+    JsonObject json = new JsonObject().put("instance", "pune");
+    JsonArray jsonArray = new JsonArray();
+    JsonObject provider =
+        new JsonObject()
+            .put("provider", "dummy id")
+            .put("cos", "cis id")
+            .put("dataset", json)
+            .put("resource", jsonArray);
+    results.add(0, provider);
+    JsonObject request =
+        new JsonObject().put(TOTAL_HITS, 50).put(ID, "dummy").put(RESULTS, results);
+    when(asyncResult.succeeded()).thenReturn(false);
+    when(asyncResult.result()).thenReturn(request);
+    doAnswer(
+            new Answer<AsyncResult<JsonObject>>() {
+              @Override
+              public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+                ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
+                return null;
+              }
+            })
+        .when(client)
+        .searchAsyncDataset(any(), any(), any());
+
+    dbService.getMlayerDataset(
+        request,
+        handler -> {
+          if (handler.succeeded()) {
+            testContext.failNow("fail");
+
+          } else {
+            verify(client, times(67)).searchAsync(any(), any(), any());
+            verify(client, times(2)).searchAsyncDataset(any(), any(), any());
+
+            testContext.completeNow();
+          }
+        });
+  }
+
+  @Test
+  @Description("test getMlayerAllDatasets method when DB Request is successful")
   public void testGetMlayerAllDatasetsSuccess(VertxTestContext testContext) {
     JsonObject request = new JsonObject();
     JsonArray jsonArray = new JsonArray();
@@ -2370,41 +2356,44 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
     provider.add("iudx:Provider");
     JsonArray accessPolicy = new JsonArray();
     JsonObject dataset_record = new JsonObject();
-    JsonObject accessPolicyJson = new JsonObject().put("resourceGroup", "abc")
-            .put("buckets",accessPolicy);
+    JsonObject accessPolicyJson =
+        new JsonObject().put("resourceGroup", "abc").put("buckets", accessPolicy);
     dataset_record
         .put(INSTANCE, "dummy instance")
         .put(PROVIDER, "dummy provider")
         .put(TYPE, provider)
-            .put("name","dummy name")
-            .put("id", "dataset id")
-            .put("description", "description of dataset")
-            .put("key","rg_id")
-            .put("doc_count",5)
-            .put(KEY,accessPolicyJson)
-            .put("access_policies", accessPolicyJson);
+        .put("name", "dummy name")
+        .put("id", "dataset id")
+        .put("description", "description of dataset")
+        .put("key", "rg_id")
+        .put("doc_count", 5)
+        .put(KEY, accessPolicyJson)
+        .put("access_policies", accessPolicyJson);
     jsonArray.add(dataset_record);
-    request.put(RESULTS, jsonArray)
-            .put("resourceGroupCount",5)
-            .put("resourceGroup", jsonArray)
-            .put(LIMIT,0)
-            .put(OFFSET, 0);
+    request
+        .put(RESULTS, jsonArray)
+        .put("resourceGroupCount", 5)
+        .put("resourceGroup", jsonArray)
+        .put(LIMIT, 0)
+        .put(OFFSET, 0);
     when(asyncResult.succeeded()).thenReturn(true);
     when(asyncResult.result()).thenReturn(request);
 
-      doAnswer(
-              new Answer<AsyncResult<JsonObject>>() {
-                  @Override
-                  public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-                      ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
-                      return null;
-                  }
-              })
-              .when(client)
-              .resourceAggregationAsync(any(), any(), any());
+    doAnswer(
+            new Answer<AsyncResult<JsonObject>>() {
+              @Override
+              public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+                ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
+                return null;
+              }
+            })
+        .when(client)
+        .resourceAggregationAsync(any(), any(), any());
 
     dbService.getMlayerAllDatasets(
-            request,"abc", handler -> {
+        request,
+        "abc",
+        handler -> {
           if (handler.succeeded()) {
             verify(client, times(6)).searchAsync(any(), any(), any());
             verify(client, times(1)).resourceAggregationAsync(any(), any(), any());
@@ -2416,138 +2405,143 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
         });
   }
 
-    @Test
-    @Description(
-            "test getMlayerAllDatasets method when hits are 0")
-    public void testGetMlayerAllDatasets0HitsFailure(VertxTestContext testContext) {
-        JsonObject request = new JsonObject();
-        JsonArray jsonArray = new JsonArray();
-        JsonArray provider = new JsonArray();
-        provider.add("iudx:Provider");
-        JsonObject dataset_record = new JsonObject();
-        dataset_record
-                .put(INSTANCE, "dummy instance")
-                .put(PROVIDER, "dummy provider")
-                .put(TYPE, provider)
-                .put("name","dummy name")
-                .put("id", "dataset id")
-                .put("description", "description of dataset")
-                .put("key","rg_id")
-                .put("doc_count",5);
-       // jsonArray.add(dataset_record);
-        request.put(RESULTS, jsonArray)
-                .put("resourceGroupCount",5)
-                .put("resourceGroup", jsonArray)
-                .put(LIMIT, 0)
-                .put(OFFSET, 0);
-        when(asyncResult.succeeded()).thenReturn(true);
-        when(asyncResult.result()).thenReturn(request);
+  @Test
+  @Description("test getMlayerAllDatasets method when hits are 0")
+  public void testGetMlayerAllDatasets0HitsFailure(VertxTestContext testContext) {
+    JsonObject request = new JsonObject();
+    JsonArray jsonArray = new JsonArray();
+    JsonArray provider = new JsonArray();
+    provider.add("iudx:Provider");
+    JsonObject dataset_record = new JsonObject();
+    dataset_record
+        .put(INSTANCE, "dummy instance")
+        .put(PROVIDER, "dummy provider")
+        .put(TYPE, provider)
+        .put("name", "dummy name")
+        .put("id", "dataset id")
+        .put("description", "description of dataset")
+        .put("key", "rg_id")
+        .put("doc_count", 5);
+    // jsonArray.add(dataset_record);
+    request
+        .put(RESULTS, jsonArray)
+        .put("resourceGroupCount", 5)
+        .put("resourceGroup", jsonArray)
+        .put(LIMIT, 0)
+        .put(OFFSET, 0);
+    when(asyncResult.succeeded()).thenReturn(true);
+    when(asyncResult.result()).thenReturn(request);
 
-        doAnswer(
-                new Answer<AsyncResult<JsonObject>>() {
-                    @Override
-                    public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-                        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
-                        return null;
-                    }
-                })
-                .when(client)
-                .resourceAggregationAsync(any(), any(), any());
+    doAnswer(
+            new Answer<AsyncResult<JsonObject>>() {
+              @Override
+              public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+                ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
+                return null;
+              }
+            })
+        .when(client)
+        .resourceAggregationAsync(any(), any(), any());
 
-        dbService.getMlayerAllDatasets(
-                request,"abc", handler -> {
-                    if (handler.succeeded()) {
-                        verify(client, times(6)).searchAsync(any(), any(), any());
-                        verify(client, times(1)).resourceAggregationAsync(any(), any(), any());
-                        testContext.failNow("fail");
+    dbService.getMlayerAllDatasets(
+        request,
+        "abc",
+        handler -> {
+          if (handler.succeeded()) {
+            verify(client, times(6)).searchAsync(any(), any(), any());
+            verify(client, times(1)).resourceAggregationAsync(any(), any(), any());
+            testContext.failNow("fail");
 
-                    } else {
-                        testContext.completeNow();
+          } else {
+            testContext.completeNow();
+          }
+        });
+  }
 
-                    }
-                });
-    }
+  @Test
+  @Description(
+      "test getMlayerAllDatasets method when DB Request is successful and type is resource Group")
+  public void testGetMlayerAllDatasetsSuccessRs(VertxTestContext testContext) {
+    JsonObject request = new JsonObject();
+    JsonArray jsonArray = new JsonArray();
+    JsonArray provider = new JsonArray();
+    provider.add("iudx:Provider");
+    JsonObject dataset_record = new JsonObject();
+    JsonObject dataset_recordRs = new JsonObject();
+    JsonArray accessPolicy = new JsonArray();
+    JsonArray jsonArrayType = new JsonArray().add(0, ITEM_TYPE_RESOURCE_GROUP);
+    JsonObject accessPolicyJson =
+        new JsonObject().put("resourceGroup", "abc").put(BUCKETS, accessPolicy);
+    dataset_record
+        .put(INSTANCE, "dummy instance")
+        .put(PROVIDER, "dummy provider")
+        .put(TYPE, provider)
+        .put("name", "dummy name")
+        .put("id", "dataset id")
+        .put("description", "description of dataset")
+        .put("key", "rg_id")
+        .put("doc_count", 5)
+        .put(KEY, accessPolicyJson)
+        .put("access_policies", accessPolicyJson);
+    dataset_recordRs
+        .put(INSTANCE, "dummy instance")
+        .put(PROVIDER, "dummy provider")
+        .put(TYPE, jsonArrayType)
+        .put("name", "dummy name")
+        .put("id", "dataset id")
+        .put("description", "description of dataset")
+        .put("key", "rg_id")
+        .put("doc_count", 5)
+        .put(KEY, accessPolicyJson)
+        .put("access_policies", accessPolicyJson);
+    jsonArray.add(dataset_record).add(dataset_recordRs);
+    request
+        .put(RESULTS, jsonArray)
+        .put("resourceGroupCount", 5)
+        .put("resourceGroup", jsonArray)
+        .put(LIMIT, 0)
+        .put(OFFSET, 0);
+    when(asyncResult.succeeded()).thenReturn(true);
+    when(asyncResult.result()).thenReturn(request);
 
-    @Test
-    @Description(
-            "test getMlayerAllDatasets method when DB Request is successful and type is resource Group")
-    public void testGetMlayerAllDatasetsSuccessRs(VertxTestContext testContext) {
-        JsonObject request = new JsonObject();
-        JsonArray jsonArray = new JsonArray();
-        JsonArray provider = new JsonArray();
-        provider.add("iudx:Provider");
-        JsonObject dataset_record = new JsonObject();
-        JsonObject dataset_recordRs = new JsonObject();
-        JsonArray accessPolicy = new JsonArray();
-        JsonArray jsonArrayType = new JsonArray().add(0,ITEM_TYPE_RESOURCE_GROUP);
-        JsonObject accessPolicyJson = new JsonObject().put("resourceGroup", "abc")
-                .put(BUCKETS, accessPolicy);
-        dataset_record
-                .put(INSTANCE, "dummy instance")
-                .put(PROVIDER, "dummy provider")
-                .put(TYPE, provider)
-                .put("name","dummy name")
-                .put("id", "dataset id")
-                .put("description", "description of dataset")
-                .put("key","rg_id")
-                .put("doc_count",5)
-                .put(KEY, accessPolicyJson)
-                .put("access_policies", accessPolicyJson);
-        dataset_recordRs
-                .put(INSTANCE, "dummy instance")
-                .put(PROVIDER, "dummy provider")
-                .put(TYPE, jsonArrayType)
-                .put("name","dummy name")
-                .put("id", "dataset id")
-                .put("description", "description of dataset")
-                .put("key","rg_id")
-                .put("doc_count",5)
-                .put(KEY, accessPolicyJson)
-                .put("access_policies", accessPolicyJson);
-        jsonArray.add(dataset_record).add(dataset_recordRs);
-        request.put(RESULTS, jsonArray)
-                .put("resourceGroupCount",5)
-                .put("resourceGroup", jsonArray)
-                .put(LIMIT, 0)
-                .put(OFFSET, 0);
-        when(asyncResult.succeeded()).thenReturn(true);
-        when(asyncResult.result()).thenReturn(request);
+    doAnswer(
+            new Answer<AsyncResult<JsonObject>>() {
+              @Override
+              public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
+                ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
+                return null;
+              }
+            })
+        .when(client)
+        .resourceAggregationAsync(any(), any(), any());
 
-        doAnswer(
-                new Answer<AsyncResult<JsonObject>>() {
-                    @Override
-                    public AsyncResult<JsonObject> answer(InvocationOnMock arg0) throws Throwable {
-                        ((Handler<AsyncResult<JsonObject>>) arg0.getArgument(2)).handle(asyncResult);
-                        return null;
-                    }
-                })
-                .when(client)
-                .resourceAggregationAsync(any(), any(), any());
+    dbService.getMlayerAllDatasets(
+        request,
+        "abc",
+        handler -> {
+          if (handler.succeeded()) {
+            // verify(client, times(1)).searchAsyncDataset(any(), any(), any());
+            verify(client, times(55)).searchAsync(any(), any(), any());
+            verify(client, times(5)).resourceAggregationAsync(any(), any(), any());
+            testContext.completeNow();
 
-        dbService.getMlayerAllDatasets(
-                request,"abc", handler -> {
-                    if (handler.succeeded()) {
-                        // verify(client, times(1)).searchAsyncDataset(any(), any(), any());
-                        verify(client, times(55)).searchAsync(any(), any(), any());
-                        verify(client, times(5)).resourceAggregationAsync(any(), any(), any());
-                        testContext.completeNow();
+          } else {
+            testContext.failNow("fail");
+          }
+        });
+  }
 
-                    } else {
-                        testContext.failNow("fail");
-                    }
-                });
-    }
-
-
-    @Test
-    @Description("test getMlayerAllDatasets method when DB Request fails")
-    public void testGetMlayerAllDatasetsResourceFails(VertxTestContext testContext) {
-        JsonObject request = new JsonObject().put(LIMIT, 0).put(OFFSET,0);
+  @Test
+  @Description("test getMlayerAllDatasets method when DB Request fails")
+  public void testGetMlayerAllDatasetsResourceFails(VertxTestContext testContext) {
+    JsonObject request = new JsonObject().put(LIMIT, 0).put(OFFSET, 0);
 
     when(asyncResult.succeeded()).thenReturn(false);
 
     dbService.getMlayerAllDatasets(
-        request,"abc", handler -> {
+        request,
+        "abc",
+        handler -> {
           if (handler.failed()) {
             // verify(client, times(1)).searchAsyncDataset(any(), any(), any());
             verify(client, times(29)).searchAsync(any(), any(), any());
@@ -2565,6 +2559,7 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
   public void testGetMlayerPopularDatasetsSuccess(VertxTestContext testContext) {
     DatabaseServiceImpl databaseService =
         new DatabaseServiceImpl(
+            webClient,
             client,
             docIndex,
             ratingIndex,
@@ -2572,41 +2567,46 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
             mlayerDomainIndex,
             nlpService,
             geoService);
-    String instanceName ="pune";
+    String instanceName = "pune";
     JsonArray accessPolicy = new JsonArray();
     JsonObject accessPolicyJson =
-        new JsonObject().put("resourcegroup", "abcd/abcd/abcd/abcd").put("instance", "instance")
-                .put(BUCKETS, accessPolicy)
-                .put("resourceGroup", "abc");
+        new JsonObject()
+            .put("resourcegroup", "abcd/abcd/abcd/abcd")
+            .put("instance", "instance")
+            .put(BUCKETS, accessPolicy)
+            .put("resourceGroup", "abc");
     JsonObject json2 =
-        new JsonObject().put("resourcegroup", "abcd/abcd/abcd/abcd").put("instance", "instance")
-                .put(BUCKETS, accessPolicy)
-                .put("resourceGroup", "abc");
+        new JsonObject()
+            .put("resourcegroup", "abcd/abcd/abcd/abcd")
+            .put("instance", "instance")
+            .put(BUCKETS, accessPolicy)
+            .put("resourceGroup", "abc");
 
     JsonArray highestCountResource = new JsonArray().add(accessPolicyJson).add(json2);
 
-        JsonArray resourceArray = new JsonArray();
-        JsonArray typeArray = new JsonArray().add(0, "iudx:ResourceGroup");
+    JsonArray resourceArray = new JsonArray();
+    JsonArray typeArray = new JsonArray().add(0, "iudx:ResourceGroup");
 
-        JsonObject instance =
-                new JsonObject()
-                        .put("name", "agra")
-                        .put("icon", "path_of_agra-icon.jpg")
-                        .put(TYPE, typeArray)
-                        .put("itemCreatedAt", "2022-12-15T04:23:28+0530")
-                        .put("id", "abcd/abcd/abcd/abcd")
-                        .put("rgid", "abcd/abcd/abcd/abcd")
-                        .put("instance", "instance")
-                        .put("itemCreatedAt", "2023-08-30T05:09:54+0530")
-                        .put(KEY, "719390c5-30c0-4339-b0f2-1be292312104")
-                        .put("doc_count", 2)
-                        .put(KEY, accessPolicyJson)
-                        .put("access_policies", accessPolicyJson)
-                        .put("resourceGroupAndProvider", resourceArray)
-                        .put("providerCount", 7);
-        resourceArray.add(instance).add(instance).add(instance).add(instance).add(instance);
-        JsonArray latestDataset = new JsonArray().add(accessPolicyJson);
-        JsonArray resultArray = new JsonArray().add(instance).add(instance).add(instance).add(instance).add(instance);
+    JsonObject instance =
+        new JsonObject()
+            .put("name", "agra")
+            .put("icon", "path_of_agra-icon.jpg")
+            .put(TYPE, typeArray)
+            .put("itemCreatedAt", "2022-12-15T04:23:28+0530")
+            .put("id", "abcd/abcd/abcd/abcd")
+            .put("rgid", "abcd/abcd/abcd/abcd")
+            .put("instance", "instance")
+            .put("itemCreatedAt", "2023-08-30T05:09:54+0530")
+            .put(KEY, "719390c5-30c0-4339-b0f2-1be292312104")
+            .put("doc_count", 2)
+            .put(KEY, accessPolicyJson)
+            .put("access_policies", accessPolicyJson)
+            .put("resourceGroupAndProvider", resourceArray)
+            .put("providerCount", 7);
+    resourceArray.add(instance).add(instance).add(instance).add(instance).add(instance);
+    JsonArray latestDataset = new JsonArray().add(accessPolicyJson);
+    JsonArray resultArray =
+        new JsonArray().add(instance).add(instance).add(instance).add(instance).add(instance);
 
     JsonObject result =
         new JsonObject()
@@ -2619,7 +2619,7 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
     mockAsyncMethod(client -> client.resourceAggregationAsync(any(), any(), any()));
     mockAsyncMethod(client -> client.searchAsyncResourceGroupAndProvider(any(), any(), any()));
     databaseService.getMlayerPopularDatasets(
-            instanceName,
+        instanceName,
         highestCountResource,
         handler -> {
           if (handler.succeeded()) {
@@ -2633,13 +2633,13 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
         });
   }
 
-
   @Test
   @Description("test getMlayerPopularDatasets method when DB Request fails")
   public void testGetMlayerPopularDatasetsFailed(VertxTestContext testContext) {
-      String instance ="";
+    String instance = "";
     DatabaseServiceImpl databaseService =
         new DatabaseServiceImpl(
+            webClient,
             client,
             docIndex,
             ratingIndex,
@@ -2650,7 +2650,7 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
     JsonArray highestCountResource = new JsonArray();
     when(asyncResult.succeeded()).thenReturn(false);
     databaseService.getMlayerPopularDatasets(
-            instance,
+        instance,
         highestCountResource,
         handler -> {
           if (handler.failed()) {
@@ -2667,14 +2667,14 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
 
   }
 
-
   @Test
   @Description(
       "test getMlayerPopularDatasets method when DB Request is successful and type equals iudx:Provider")
   public void testGetMlayerPopularDatasetsProviderSuccess(VertxTestContext testContext) {
-      String instanceName ="";
+    String instanceName = "";
     DatabaseServiceImpl databaseService =
         new DatabaseServiceImpl(
+            webClient,
             client,
             docIndex,
             ratingIndex,
@@ -2683,64 +2683,78 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
             nlpService,
             geoService);
     JsonArray accessPolicy = new JsonArray();
-    JsonObject record = new JsonObject().put("rgid", "duumy-id")
+    JsonObject record =
+        new JsonObject()
+            .put("rgid", "duumy-id")
             .put("resourceGroup", "abc")
             .put(BUCKETS, accessPolicy);
     JsonObject json2 = new JsonObject().put("rgid", "duumy-id");
 
     JsonArray highestCountResource = new JsonArray().add(record).add(json2);
 
-        JsonArray resourceArray = new JsonArray();
-        JsonArray typeArray = new JsonArray().add(0, "iudx:Provider");
+    JsonArray resourceArray = new JsonArray();
+    JsonArray typeArray = new JsonArray().add(0, "iudx:Provider");
 
-        JsonObject instanceRg =
-                new JsonObject()
-                        .put("name", "agra")
-                        .put("icon", "path_of_agra-icon.jpg")
-                        .put(TYPE, typeArray)
-                        .put("resourceGroup", "abc")
-                        .put(KEY, "719390c5-30c0-4339-b0f2-1be292312104")
-                        .put("doc_count", 2)
-                        .put("id", "719390c5-30c0-4339-b0f2-1be292312104")
-                        .put(KEY, record)
-                        .put("access_policies", record)
-                        .put("resourceGroupAndProvider", resourceArray)
-                        .put("providerCount", 7);
-        JsonObject instance =
-                new JsonObject()
-                        .put("name", "agra")
-                        .put("icon", "path_of_agra-icon.jpg")
-                        .put(TYPE, typeArray)
-                        .put("resourceGroup", "abc")
-                        .put(KEY, "719390c5-30c0-4339-b0f2-1be292312104")
-                        .put("doc_count", 2)
-                        .put("id", "719390c5-30c0-4339-b0f2-1be292312104")
-                        .put(KEY, record)
-                        .put("access_policies", record)
-                        .put("resourceGroupAndProvider", resourceArray)
-                        .put("providerCount", 7);
-        resourceArray.add(instance).add(instanceRg).add(instanceRg).add(instanceRg)
-                .add(instanceRg).add(instanceRg).add(instanceRg);
-      JsonArray resultArray = new JsonArray().add(instanceRg).add(instanceRg).add(instanceRg)
-              .add(instanceRg).add(instanceRg).add(instanceRg);
+    JsonObject instanceRg =
+        new JsonObject()
+            .put("name", "agra")
+            .put("icon", "path_of_agra-icon.jpg")
+            .put(TYPE, typeArray)
+            .put("resourceGroup", "abc")
+            .put(KEY, "719390c5-30c0-4339-b0f2-1be292312104")
+            .put("doc_count", 2)
+            .put("id", "719390c5-30c0-4339-b0f2-1be292312104")
+            .put(KEY, record)
+            .put("access_policies", record)
+            .put("resourceGroupAndProvider", resourceArray)
+            .put("providerCount", 7);
+    JsonObject instance =
+        new JsonObject()
+            .put("name", "agra")
+            .put("icon", "path_of_agra-icon.jpg")
+            .put(TYPE, typeArray)
+            .put("resourceGroup", "abc")
+            .put(KEY, "719390c5-30c0-4339-b0f2-1be292312104")
+            .put("doc_count", 2)
+            .put("id", "719390c5-30c0-4339-b0f2-1be292312104")
+            .put(KEY, record)
+            .put("access_policies", record)
+            .put("resourceGroupAndProvider", resourceArray)
+            .put("providerCount", 7);
+    resourceArray
+        .add(instance)
+        .add(instanceRg)
+        .add(instanceRg)
+        .add(instanceRg)
+        .add(instanceRg)
+        .add(instanceRg)
+        .add(instanceRg);
+    JsonArray resultArray =
+        new JsonArray()
+            .add(instanceRg)
+            .add(instanceRg)
+            .add(instanceRg)
+            .add(instanceRg)
+            .add(instanceRg)
+            .add(instanceRg);
 
-
-      JsonObject result = new JsonObject().put(TOTAL_HITS, 1).put(RESULTS, resultArray);
+    JsonObject result = new JsonObject().put(TOTAL_HITS, 1).put(RESULTS, resultArray);
     when(asyncResult.result()).thenReturn(result);
     when(asyncResult.succeeded()).thenReturn(true);
-      mockAsyncMethod(client -> client.searchAsync(any(), any(), any()));
-      mockAsyncMethod(client -> client.resourceAggregationAsync(any(), any(), any()));
-      mockAsyncMethod(client -> client.searchAsyncResourceGroupAndProvider(any(), any(), any()));
+    mockAsyncMethod(client -> client.searchAsync(any(), any(), any()));
+    mockAsyncMethod(client -> client.resourceAggregationAsync(any(), any(), any()));
+    mockAsyncMethod(client -> client.searchAsyncResourceGroupAndProvider(any(), any(), any()));
 
-
-      databaseService.getMlayerPopularDatasets(
-            instanceName,
+    databaseService.getMlayerPopularDatasets(
+        instanceName,
         highestCountResource,
         handler -> {
           if (handler.succeeded()) {
             verify(DatabaseServiceImpl.client, times(40)).searchAsync(any(), any(), any());
-            verify(DatabaseServiceImpl.client, times(3)).searchAsyncResourceGroupAndProvider(any(), any(), any());
-            verify(DatabaseServiceImpl.client, times(4)).resourceAggregationAsync(any(), any(), any());
+            verify(DatabaseServiceImpl.client, times(3))
+                .searchAsyncResourceGroupAndProvider(any(), any(), any());
+            verify(DatabaseServiceImpl.client, times(4))
+                .resourceAggregationAsync(any(), any(), any());
             testContext.completeNow();
           } else {
             testContext.failNow("fail");
@@ -2778,78 +2792,71 @@ public void testGetMlayerInstance(VertxTestContext testContext) {
     when(asyncResult.succeeded()).thenReturn(true);
     when(asyncResult.result()).thenReturn(request);
 
-     dbService.deleteItem(
-                request,
-                handler -> {
-                    if (handler.succeeded()) {
-                        vertxTestContext.failNow("Fail");
-                    } else {
-                        vertxTestContext.completeNow();
-                    }
-                });
-    }
+    dbService.deleteItem(
+        request,
+        handler -> {
+          if (handler.succeeded()) {
+            vertxTestContext.failNow("Fail");
+          } else {
+            vertxTestContext.completeNow();
+          }
+        });
+  }
 
-    @Test
-    @Description("testing method search Query when request is successful")
-    public void testSearchQueryTextSearch(VertxTestContext vertxTestContext) {
-        JsonObject request = new JsonObject().put(SEARCH_TYPE, TEXTSEARCH_REGEX)
-                .put(Q_VALUE, "all")
-                .put(INSTANCE, null);
-        when(asyncResult.succeeded()).thenReturn(true);
-        when(asyncResult.result()).thenReturn(request);
+  @Test
+  @Description("testing method search Query when request is successful")
+  public void testSearchQueryTextSearch(VertxTestContext vertxTestContext) {
+    JsonObject request =
+        new JsonObject().put(SEARCH_TYPE, TEXTSEARCH_REGEX).put(Q_VALUE, "all").put(INSTANCE, null);
+    when(asyncResult.succeeded()).thenReturn(true);
+    when(asyncResult.result()).thenReturn(request);
 
-        dbService.searchQuery(
-                request,
-                handler -> {
-                    if (handler.succeeded()) {
-                        verify(client, times(21)).searchAsync(any(), any(), any());
-                        vertxTestContext.completeNow();
+    dbService.searchQuery(
+        request,
+        handler -> {
+          if (handler.succeeded()) {
+            verify(client, times(21)).searchAsync(any(), any(), any());
+            vertxTestContext.completeNow();
 
+          } else {
+            vertxTestContext.failNow("Fail");
+          }
+        });
+  }
 
-                    } else {
-                        vertxTestContext.failNow("Fail");
+  @Test
+  @Description("testing method search Query when request is successful")
+  public void testDeleteItem(VertxTestContext vertxTestContext) {
+    JsonArray jsonArray = new JsonArray().add(0, "id");
+    JsonObject request = new JsonObject().put("id", "item id").put(RESULTS, jsonArray);
+    when(asyncResult.failed()).thenReturn(true);
+    when(asyncResult.cause()).thenReturn(throwable);
+    when(asyncResult.result()).thenReturn(request);
 
-                    }
-                });
-    }
+    dbService.deleteItem(
+        request,
+        handler -> {
+          if (handler.succeeded()) {
+            verify(client, times(1)).searchGetId(any(), any(), any());
+            vertxTestContext.failNow("Fail");
 
+          } else {
+            vertxTestContext.completeNow();
+          }
+        });
+  }
 
-    @Test
-    @Description("testing method search Query when request is successful")
-    public void testDeleteItem(VertxTestContext vertxTestContext) {
-        JsonArray jsonArray = new JsonArray().add(0,"id");
-        JsonObject request = new JsonObject()
-                .put("id", "item id")
-                .put(RESULTS, jsonArray);
-        when(asyncResult.failed()).thenReturn(true);
-        when(asyncResult.cause()).thenReturn(throwable);
-        when(asyncResult.result()).thenReturn(request);
+  private void mockAsyncMethod(Consumer<ElasticClient> asyncMethodMock) {
+    doAnswer(
+            invocation -> {
+              Handler<AsyncResult<JsonObject>> handler = invocation.getArgument(2);
+              handler.handle(asyncResult);
+              return null;
+            })
+        .when(client);
 
-        dbService.deleteItem(
-                request,
-                handler -> {
-                    if (handler.succeeded()) {
-                        verify(client, times(1)).searchGetId(any(), any(), any());
-                        vertxTestContext.failNow("Fail");
-
-
-                    } else {
-                        vertxTestContext.completeNow();
-
-
-                    }
-                });
-    }
-
-    private void mockAsyncMethod(Consumer<ElasticClient> asyncMethodMock) {
-        doAnswer(invocation -> {
-            Handler<AsyncResult<JsonObject>> handler = invocation.getArgument(2);
-            handler.handle(asyncResult);
-            return null;
-        }).when(client);
-
-        asyncMethodMock.accept(client);
-    }
+    asyncMethodMock.accept(client);
+  }
 
   @Test
   @Description("test getMlayerProviders method when instance is provided")

--- a/src/test/java/iudx/catalogue/server/mlayer/vocabulary/DataModelTest.java
+++ b/src/test/java/iudx/catalogue/server/mlayer/vocabulary/DataModelTest.java
@@ -1,0 +1,171 @@
+package iudx.catalogue.server.mlayer.vocabulary;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import io.vertx.core.*;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import iudx.catalogue.server.database.ElasticClient;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(VertxExtension.class)
+public class DataModelTest {
+  private static final Logger LOGGER = LogManager.getLogger(DataModelTest.class);
+  MultiMap mockHeaders = mock(MultiMap.class);
+  @Mock private WebClient webClient;
+  @Mock private ElasticClient mockElasticClient;
+  @Mock private HttpResponse<Buffer> mockHttpResponse;
+  @Mock private HttpRequest<Buffer> mockHttpRequest;
+  @Mock private Buffer mockBuffer;
+  @InjectMocks private DataModel dataModel;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    dataModel = new DataModel(webClient, mockElasticClient, "test-index");
+  }
+
+  @Test
+  void testGetDataModelInfo_Success(VertxTestContext vertxTestContext) {
+    // Mocking Elasticsearch client's async search
+    when(mockElasticClient.searchAsync(anyString(), anyString(), any()))
+        .thenAnswer(
+            invocation -> {
+              ((Handler<AsyncResult<JsonObject>>) invocation.getArgument(2))
+                  .handle(
+                      Future.succeededFuture(
+                          new JsonObject()
+                              .put(
+                                  "results",
+                                  new JsonArray()
+                                      .add(
+                                          new JsonObject()
+                                              .put("@context", "https://example.com/")
+                                              .put(
+                                                  "type",
+                                                  new JsonArray()
+                                                      .add("dummy")
+                                                      .add("iudx:Resource"))))));
+              vertxTestContext.completeNow();
+              return null;
+            });
+    lenient().when(webClient.getAbs(anyString())).thenReturn(mockHttpRequest);
+    lenient().when(mockHttpRequest.send()).thenReturn(Future.succeededFuture(mockHttpResponse));
+    lenient()
+        .when(mockHttpResponse.body())
+        .thenReturn(
+            Buffer.buffer(
+                "{ \"@graph\": [ { \"@id\": \"iudx:Resource\", \"rdfs:subClassOf\": { \"@id\": \"iudx:SuperClass\" } } ] }"));
+
+    Future<JsonObject> resultFuture = dataModel.getDataModelInfo();
+
+    resultFuture.onComplete(
+        ar -> {
+          if (ar.succeeded()) {
+            JsonObject result = ar.result();
+            assertNotNull(result);
+            assertEquals("SuperClass", result.getString("Resource"));
+          } else {
+            fail("Test failed with exception: " + ar.cause().getMessage());
+            vertxTestContext.failNow(ar.cause());
+          }
+        });
+  }
+
+  @Test
+  void testHandleDataModelResponse_Success(VertxTestContext vertxTestContext) {
+    Promise<JsonObject> promise = Promise.promise();
+    JsonObject classIdToSubClassMap = new JsonObject();
+    AtomicInteger pendingRequests = new AtomicInteger(1);
+
+    // Mocking AsyncResult for successful response
+    AsyncResult<HttpResponse<Buffer>> dmAr = mock(AsyncResult.class);
+    when(dmAr.succeeded()).thenReturn(true);
+    when(dmAr.result()).thenReturn(mockHttpResponse);
+    when(mockHttpResponse.body()).thenReturn(mockBuffer);
+    when(mockHttpResponse.headers()).thenReturn(mockHeaders);
+    when(mockHttpResponse.headers().get(anyString())).thenReturn("application/json");
+    when(mockBuffer.toJsonObject())
+        .thenReturn(
+            new JsonObject()
+                .put(
+                    "@graph",
+                    new JsonArray()
+                        .add(
+                            new JsonObject()
+                                .put("@id", "iudx:Class")
+                                .put(
+                                    "rdfs:subClassOf",
+                                    new JsonObject().put("@id", "iudx:SubClass")))));
+    Map<String, String> idToClassIdMap = new HashMap<>();
+    idToClassIdMap.put("id", "Class");
+    dataModel.handleDataModelResponse(
+        dmAr, "Class", idToClassIdMap, classIdToSubClassMap, pendingRequests, promise, "dmUrl");
+
+    // Verify the result
+    promise
+        .future()
+        .onComplete(
+            ar -> {
+              if (ar.succeeded()) {
+                JsonObject result = ar.result();
+                assertNotNull(result);
+                assertEquals("SubClass", result.getString("id"));
+                vertxTestContext.completeNow();
+              } else {
+                fail("Test failed with exception: " + ar.cause().getMessage());
+                vertxTestContext.failNow(ar.cause());
+              }
+            });
+  }
+
+  @Test
+  void testHandleDataModelResponse_Failed(VertxTestContext vertxTestContext) {
+    Promise<JsonObject> promise = Promise.promise();
+    JsonObject classIdToSubClassMap = new JsonObject();
+    AtomicInteger pendingRequests = new AtomicInteger(1);
+
+    // Mocking AsyncResult for failed response
+    AsyncResult<HttpResponse<Buffer>> dmAr = mock(AsyncResult.class);
+    when(dmAr.succeeded()).thenReturn(false);
+    when(dmAr.cause()).thenReturn(new Throwable("Failed"));
+    Map<String, String> idToClassIdMap = new HashMap<>();
+    idToClassIdMap.put("id", "classId1");
+    dataModel.handleDataModelResponse(
+        dmAr, "id", idToClassIdMap, classIdToSubClassMap, pendingRequests, promise, "dmUrl");
+
+    // Verify the result
+    promise
+        .future()
+        .onComplete(
+            ar -> {
+              if (ar.succeeded()) {
+                JsonObject result = ar.result();
+                assertNotNull(result);
+                assertTrue(result.isEmpty());
+                vertxTestContext.completeNow();
+              } else {
+                fail("Test failed with exception: " + ar.cause().getMessage());
+                vertxTestContext.failNow(ar.cause());
+              }
+            });
+  }
+}

--- a/src/test/java/iudx/catalogue/server/mlayer/vocabulary/DataModelTest.java
+++ b/src/test/java/iudx/catalogue/server/mlayer/vocabulary/DataModelTest.java
@@ -44,7 +44,7 @@ public class DataModelTest {
   }
 
   @Test
-  void testGetDataModelInfo_Success(VertxTestContext vertxTestContext) {
+  void SuccessGetDataModelInfoTest(VertxTestContext vertxTestContext) {
     JsonObject respone =
         new JsonObject()
             .put(
@@ -87,7 +87,7 @@ public class DataModelTest {
   }
 
   @Test
-  void testHandleDataModelResponse_Success(VertxTestContext vertxTestContext) {
+  void SuccessHandleDataModelResponseTest(VertxTestContext vertxTestContext) {
     Promise<JsonObject> promise = Promise.promise();
     JsonObject response =
         new JsonObject()
@@ -132,7 +132,7 @@ public class DataModelTest {
   }
 
   @Test
-  void testHandleDataModelResponse_Failed(VertxTestContext vertxTestContext) {
+  void FailureHandleDataModelResponseTest(VertxTestContext vertxTestContext) {
     Promise<JsonObject> promise = Promise.promise();
     JsonObject classIdToSubClassMap = new JsonObject();
     AtomicInteger pendingRequests = new AtomicInteger(1);


### PR DESCRIPTION
- **Issue:**
While fetching data model information from the voc server using the WebClient, we encountered an OutOfMemoryException due to a memory leak. This occurred because a new WebClient & Vertx instance was being created every time the request was made, leading to excessive memory usage creating lot of threads which were never being down once created.
- **Fix:**
To resolve the issue, made the following changes:
    - Singleton Pattern for WebClient:
        ◦ Instead of creating a new WebClient instance for each request, instantiated a single WebClient instance and reused it across the application.
        ◦ The WebClient instance was created in the DatabaseVerticle and then passed around where needed.