### PR TITLE
popularDataset API

### DIFF
--- a/src/main/java/iudx/catalogue/server/database/Constants.java
+++ b/src/main/java/iudx/catalogue/server/database/Constants.java
@@ -45,6 +45,7 @@ public class Constants {
   public static final String SOURCE_AND_ID_GEOQUERY = "SOURCE_ID_GEOQUERY";
   public static final String RESOURCE_AGGREGATION_ONLY = "RESOURCE_AGGREGATION";
   public static final String PROVIDER_AGGREGATION_ONLY = "PROVIDER_AGGREGATION";
+  public static final String LATEST_RG_AGG = "LATEST_RG_AGG";
 
   /** Some queries. */
   public static final String LIST_INSTANCES_QUERY =
@@ -148,8 +149,7 @@ public class Constants {
           + "{\"includes\":[\"type\",\"id\",\"label\",\"accessPolicy\","
           + "\"tags\",\"instance\",\"provider\",\"resourceServerRegURL\","
           + "\"description\",\"cosURL\",\"cos\",\"resourceGroup\", "
-          + "\"itemCreatedAt\", \"icon_base64\"]},"
-          + "\"size\":10000}";
+          + "\"itemCreatedAt\", \"icon_base64\"]},\"size\":10000}";
   public static final String GET_MLAYER_DATASET =
       "{\"query\":{\"bool\":{\"should\":[{\"bool\":{\"must\":[{\"match\":{\"id.keyword\":\"$1\"}}"
           + ",{\"match\": {\"type.keyword\": \"iudx:ResourceGroup\"}}]}},{\"bool\":{\"must\":"
@@ -164,7 +164,7 @@ public class Constants {
           + " \"dataDescriptor\", \"@context\", \"dataQualityFile\", \"dataSampleFile\","
           + " \"resourceType\", \"resourceServerRegURL\",\"resourceType\","
           + "\"location\", \"iudxResourceAPIs\", \"itemCreatedAt\",\"nsdi\", "
-          +  "\"icon_base64\"]},\"size\": 10000}";
+          + "\"icon_base64\"]},\"size\": 10000}";
   public static final String RESOURCE_ACCESSPOLICY_COUNT =
       "{\"size\": 0,\"aggs\":{\"results\":{\"terms\":{\"field\":\"resourceGroup.keyword\","
           + "\"size\":10000},\"aggs\":{\"access_policies\":{\"terms\":{\"field\":"
@@ -188,6 +188,28 @@ public class Constants {
           + "\"description\",\"type\",\"resourceGroup\","
           + "\"accessPolicy\",\"provider\",\"itemCreatedAt\",\"instance\",\"label\"]},"
           + "\"size\":10000}";
+  public static final String GET_LATEST_TOTAL_RG =
+          "{\"size\":6,\"from\": 0,\"sort\":[{\"itemCreatedAt\":{\"order\": \"desc\"}}],"
+          + "\"query\":{\"bool\":{\"must\":[{\"match\":{\"type\":\"iudx:ResourceGroup\"}}"
+          + "]}},\"aggs\":{\"resourceGroupCount\":{\"filter\":{\"term\": {\"type.keyword\":"
+          + " \"iudx:ResourceGroup\"}}},\"resourceCount\":{\"global\":{},\"aggs\":"
+          + "{\"Resources\":{\"filter\":{\"term\":{\"type.keyword\": \"iudx:Resource\""
+          + "}}}}},\"providerCount\":{\"global\":{},\"aggs\":{\"Providers\":{\"filter\":{\"term\""
+          + ":{\"type.keyword\": \"iudx:Provider\"}}}}}},\"_source\":{\"includes\":"
+          + "[\"id\",\"description\",\"type\",\"resourceGroup\",\"accessPolicy\",\"provider\","
+          + "\"itemCreatedAt\",\"instance\",\"label\"]}}";
+  public static final String GET_PROVIDERS_AND_POPULAR_RG =
+          "{\"size\": 10000,\"_source\":[\"id\",\"description\",\"type\",\"resourceGroup\","
+          + "\"accessPolicy\",\"provider\",\"itemCreatedAt\",\"instance\",\"label\"],\"query\":"
+          + " {\"bool\": {\"should\":[{\"terms\":{\"id.keyword\": $1}},{\"term\": "
+          + "{\"type.keyword\": \"iudx:Provider\"}}]}}}";
+  public static final String GET_CATEGORIZED_RESOURCES_AP =
+          "{\"size\": 0, \"query\": {\"terms\": {\"resourceGroup.keyword\": $1}}, "
+          + "\"aggs\": {\"results\": {\"terms\": {\"field\": \"resourceGroup.keyword\","
+          + "\"size\": 10000},\"aggs\": {\"access_policies\": {\"terms\": {\"field\": "
+          + "\"accessPolicy.keyword\",\"size\": 10000},\"aggs\": {\"accessPolicy_count\":"
+          + " {\"value_count\": {\"field\": \"accessPolicy.keyword\"}}}},"
+          + "\"resource_count\": {\"value_count\": {\"field\": \"id.keyword\"}}}}}}";
   public static final String GET_SORTED_MLAYER_INSTANCES =
       "{\"query\": {\"match_all\":{}},\"sort\":[{\"name\":\"asc\"}],\"_source\": "
           + "{\"includes\": [\"name\",\"cover\",\"icon\"]},\"size\":10000}";

--- a/src/main/java/iudx/catalogue/server/database/ElasticClient.java
+++ b/src/main/java/iudx/catalogue/server/database/ElasticClient.java
@@ -86,6 +86,7 @@ public final class ElasticClient {
                   .setTotalHits(totalHits);
           if (totalHits > 0) {
             JsonArray results = new JsonArray();
+            JsonObject aggregationResult = new JsonObject();
 
             if ((options == SOURCE_ONLY
                     || options == DOC_IDS_ONLY
@@ -102,6 +103,31 @@ public final class ElasticClient {
                           .getJsonObject(RESULTS)
                           .getJsonArray(BUCKETS);
                 }
+                if (options == LATEST_RG_AGG) {
+                  results = responseJson.getJsonObject(HITS).getJsonArray(HITS);
+                  aggregationResult =
+                      new JsonObject()
+                          .put(
+                              RESOURCE_GROUP_COUNT,
+                              responseJson
+                                  .getJsonObject(AGGREGATIONS)
+                                  .getJsonObject(RESOURCE_GROUP_COUNT)
+                                  .getInteger(DOC_COUNT))
+                          .put(
+                              RESOURCE_COUNT,
+                              responseJson
+                                  .getJsonObject(AGGREGATIONS)
+                                  .getJsonObject(RESOURCE_COUNT)
+                                  .getJsonObject("Resources")
+                                  .getInteger(DOC_COUNT))
+                          .put(
+                              PROVIDER_COUNT,
+                              responseJson
+                                  .getJsonObject(AGGREGATIONS)
+                                  .getJsonObject(PROVIDER_COUNT)
+                                  .getJsonObject("Providers")
+                                  .getInteger(DOC_COUNT));
+                }
 
             for (int i = 0; i < results.size(); i++) {
               if (options == SOURCE_ONLY) {
@@ -117,6 +143,13 @@ public final class ElasticClient {
               if (options == AGGREGATION_ONLY) {
                 responseMsg.addResult(results.getJsonObject(i).getString(KEY));
               }
+              if (options == LATEST_RG_AGG) {
+                    JsonObject source = results.getJsonObject(i).getJsonObject(SOURCE);
+                    source.remove(SUMMARY_KEY);
+                    source.remove(WORD_VECTOR_KEY);
+                    responseMsg.addResult(source);
+                    responseMsg.response.put("count", aggregationResult);
+                  }
               if (options == RATING_AGGREGATION_ONLY) {
                 JsonObject result = new JsonObject()
                         .put(ID, results.getJsonObject(i).getString(KEY))
@@ -330,6 +363,18 @@ public final class ElasticClient {
     LOGGER.debug(query);
     LOGGER.debug(queryRequest);
     Future<JsonObject> future = searchAsync(queryRequest, RESOURCE_AGGREGATION_ONLY);
+    future.onComplete(resultHandler);
+    return this;
+  }
+
+  public ElasticClient searchLatestResource(
+      String query, String index, Handler<AsyncResult<JsonObject>> resultHandler) {
+    Request queryRequest =
+        new Request(
+            REQUEST_GET,
+            index + "/_search" + "?filter_path=aggregations,hits.total.value,hits.hits._source");
+    queryRequest.setJsonEntity(query);
+    Future<JsonObject> future = searchAsync(queryRequest, "LATEST_RG_AGG");
     future.onComplete(resultHandler);
     return this;
   }

--- a/src/main/java/iudx/catalogue/server/database/mlayer/MlayerDataset.java
+++ b/src/main/java/iudx/catalogue/server/database/mlayer/MlayerDataset.java
@@ -156,7 +156,8 @@ public class MlayerDataset {
 
     gettingAllDatasets(query, datasetResult);
     allMlayerInstance(instanceResult);
-    gettingResourceAccessPolicyCount(resourceCount);
+    String getResourceAP = RESOURCE_ACCESSPOLICY_COUNT;
+    gettingResourceAccessPolicyCount(getResourceAP, resourceCount);
 
     CompositeFuture.all(instanceResult.future(), datasetResult.future(), resourceCount.future())
         .onComplete(
@@ -377,9 +378,9 @@ public class MlayerDataset {
         });
   }
 
-  public void gettingResourceAccessPolicyCount(Promise<JsonObject> resourceCountResult) {
+  public void gettingResourceAccessPolicyCount(
+          String query, Promise<JsonObject> resourceCountResult) {
     LOGGER.debug("Getting resource item count");
-    String query = RESOURCE_ACCESSPOLICY_COUNT;
     client.resourceAggregationAsync(
         query,
         docIndex,

--- a/src/main/java/iudx/catalogue/server/database/mlayer/MlayerPopularDatasets.java
+++ b/src/main/java/iudx/catalogue/server/database/mlayer/MlayerPopularDatasets.java
@@ -1,6 +1,7 @@
 package iudx.catalogue.server.database.mlayer;
 
 import static iudx.catalogue.server.database.Constants.*;
+import static iudx.catalogue.server.database.Constants.GET_PROVIDERS_AND_POPULAR_RG;
 import static iudx.catalogue.server.util.Constants.*;
 import static iudx.catalogue.server.validator.Constants.VALIDATION_FAILURE_MSG;
 
@@ -47,7 +48,11 @@ public class MlayerPopularDatasets {
     Promise<JsonObject> datasetResult = Promise.promise();
 
     searchSortedMlayerInstances(instanceResult);
-    datasets(instance, datasetResult, frequentlyUsedResourceGroup);
+    if (instance.isBlank()) {
+      datasets(datasetResult, frequentlyUsedResourceGroup);
+    } else {
+      datasets(instance, datasetResult, frequentlyUsedResourceGroup);
+    }
     allMlayerDomains(domainResult);
     CompositeFuture.all(instanceResult.future(), domainResult.future(), datasetResult.future())
         .onComplete(
@@ -174,12 +179,8 @@ public class MlayerPopularDatasets {
 
   private void datasets(
       String instance, Promise<JsonObject> datasetResult, JsonArray frequentlyUsedResourceGroup) {
-    String providerAndResources = "";
-    if (instance.isBlank()) {
-      providerAndResources = GET_PROVIDER_AND_RESOURCEGROUP;
-    } else {
-      providerAndResources = GET_DATASET_BY_INSTANCE.replace("$1", instance);
-    }
+    String providerAndResources = GET_DATASET_BY_INSTANCE.replace("$1", instance);
+
     client.searchAsyncResourceGroupAndProvider(
         providerAndResources,
         docIndex,
@@ -188,11 +189,8 @@ public class MlayerPopularDatasets {
             ArrayList<JsonObject> latestDatasetArray = new ArrayList<JsonObject>();
             Map<String, JsonObject> resourceGroupMap = new HashMap<>();
             Map<String, String> providerDescription = new HashMap<>();
-            if (getCatRecords
-                    .result()
-                    .getJsonArray(RESULTS).isEmpty()) {
+            if (getCatRecords.result().getJsonArray(RESULTS).isEmpty()) {
               datasetResult.handle(Future.failedFuture(NO_CONTENT_AVAILABLE));
-
             }
 
             JsonArray results =
@@ -205,8 +203,10 @@ public class MlayerPopularDatasets {
 
             Promise<JsonObject> resourceCount = Promise.promise();
             MlayerDataset mlayerDataset = new MlayerDataset(client, docIndex, mlayerInstanceIndex);
+            String getResourceAP = RESOURCE_ACCESSPOLICY_COUNT;
+
             // function to get the resource group items count
-            mlayerDataset.gettingResourceAccessPolicyCount(resourceCount);
+            mlayerDataset.gettingResourceAccessPolicyCount(getResourceAP, resourceCount);
             resourceCount
                 .future()
                 .onComplete(
@@ -291,10 +291,7 @@ public class MlayerPopularDatasets {
                         for (int resourceIndex = 0;
                             resourceIndex < frequentlyUsedResourceGroup.size();
                             resourceIndex++) {
-                          String id =
-                              frequentlyUsedResourceGroup
-                                  .getJsonObject(resourceIndex)
-                                  .getString("resource_group");
+                          String id = frequentlyUsedResourceGroup.getString(resourceIndex);
                           if (resourceGroupMap.containsKey(id)) {
                             JsonObject resourceGroup = resourceGroupMap.get(id);
                             resourceGroup.put(
@@ -342,6 +339,190 @@ public class MlayerPopularDatasets {
                       }
                     });
 
+          } else {
+            LOGGER.error("Fail: failed DB request");
+            datasetResult.handle(Future.failedFuture(internalErrorResp));
+          }
+        });
+  }
+
+  /**
+   * This API forms the response when an instance is not provided. The process involves several
+   * steps: 1) Retrieve the top six newly created resource groups, along with counts of associated
+   * RIs, RGs, and providers from Elasticsearch
+   *
+   * <p>2) Using the frequentlyUsedResourceGroup array, gather all resource groups and providers
+   * listed in that array from Elasticsearch Then, create a HashMap that maps provider IDs to their
+   * descriptions.
+   *
+   * <p>3) Populate the popularDataset array, ensuring it contains at least six items.
+   *
+   * <p>4) Assemble an array of twelve resource groups (six from popular resource groups and six
+   * from latest resource groups). Retrieve their resource item counts and access policies from
+   * Elasticsearch.
+   *
+   * <p>5) Using the Elasticsearch results, populate all items with their access policies and total
+   * resource counts.
+   *
+   * @param datasetResult the resulting dataset to be completed
+   * @param frequentlyUsedResourceGroup an array of frequently used resource groups
+   */
+  private void datasets(Promise<JsonObject> datasetResult, JsonArray frequentlyUsedResourceGroup) {
+
+    String latestResourceGroup = GET_LATEST_TOTAL_RG;
+    client.searchLatestResource(
+        latestResourceGroup,
+        docIndex,
+        latestRgHandler -> {
+          if (latestRgHandler.succeeded()) {
+            if (latestRgHandler.result().getJsonArray(RESULTS).isEmpty()) {
+              datasetResult.handle(Future.failedFuture(NO_CONTENT_AVAILABLE));
+            }
+            JsonArray latestDatasets = latestRgHandler.result().getJsonArray(RESULTS);
+            int resourceGroupCount =
+                latestRgHandler.result().getJsonObject("count").getInteger("resourceGroupCount");
+
+            int resourcesCount =
+                latestRgHandler.result().getJsonObject("count").getInteger("resourceCount");
+
+            int providerCount =
+                latestRgHandler.result().getJsonObject("count").getInteger("providerCount");
+
+            String providersAndPopularRgs =
+                GET_PROVIDERS_AND_POPULAR_RG.replace("$1", frequentlyUsedResourceGroup.toString());
+
+            client.searchAsync(
+                providersAndPopularRgs,
+                docIndex,
+                providerAndPopularRgHandler -> {
+                  if (providerAndPopularRgHandler.succeeded()) {
+                    if (providerAndPopularRgHandler.result().getJsonArray(RESULTS).isEmpty()) {
+                      datasetResult.handle(Future.failedFuture(NO_CONTENT_AVAILABLE));
+                    }
+                    Map<String, String> providerDetails = new HashMap<>();
+                    JsonArray popularDatasets = new JsonArray();
+
+                    for (int count = 0;
+                        count < providerAndPopularRgHandler.result().getJsonArray(RESULTS).size();
+                        count++) {
+
+                      JsonObject resultItem =
+                          providerAndPopularRgHandler
+                              .result()
+                              .getJsonArray(RESULTS)
+                              .getJsonObject(count);
+                      String itemType = Util.getItemType(resultItem);
+                      if (itemType.equals(VALIDATION_FAILURE_MSG)) {
+                        datasetResult.handle(Future.failedFuture(VALIDATION_FAILURE_MSG));
+                      }
+
+                      if (ITEM_TYPE_PROVIDER.equals(itemType)) {
+
+                        providerDetails.put(
+                            resultItem.getString(ID), resultItem.getString(DESCRIPTION_ATTR));
+                      } else if (ITEM_TYPE_RESOURCE_GROUP.equals(itemType)) {
+                        popularDatasets.add(resultItem);
+                      }
+                    }
+                    int datasetIndex = 0;
+
+                    while (popularDatasets.size() < POPULAR_DATASET_COUNT) {
+
+                      if (!frequentlyUsedResourceGroup.contains(
+                          latestDatasets.getJsonObject(datasetIndex).getString("id"))) {
+                        popularDatasets.add(latestDatasets.getJsonObject(datasetIndex));
+                        datasetIndex++;
+                      }
+                    }
+                    JsonArray allRgId = new JsonArray();
+                    for (int count = 0; count < popularDatasets.size(); count++) {
+                      allRgId.add(popularDatasets.getJsonObject(count).getString(ID));
+                      allRgId.add(latestDatasets.getJsonObject(count).getString(ID));
+                    }
+
+                    String getCategorizedResourceAP = GET_CATEGORIZED_RESOURCES_AP;
+                    getCategorizedResourceAP =
+                        getCategorizedResourceAP.replace("$1", allRgId.toString());
+
+                    Promise<JsonObject> resourceCount = Promise.promise();
+                    MlayerDataset mlayerDataset =
+                        new MlayerDataset(client, docIndex, mlayerInstanceIndex);
+                    mlayerDataset.gettingResourceAccessPolicyCount(
+                        getCategorizedResourceAP, resourceCount);
+
+                    resourceCount
+                        .future()
+                        .onComplete(
+                            handler -> {
+                              if (handler.succeeded()) {
+                                JsonObject resourceItemCount =
+                                    resourceCount
+                                        .future()
+                                        .result()
+                                        .getJsonObject("resourceItemCount");
+                                JsonObject resourceAccessPolicy =
+                                    resourceCount
+                                        .future()
+                                        .result()
+                                        .getJsonObject("resourceAccessPolicy");
+
+                                int totalResourceItem = 0;
+                                for (JsonArray datasets :
+                                    Arrays.asList(popularDatasets, latestDatasets)) {
+                                  for (int i = 0; i < datasets.size(); i++) {
+                                    JsonObject datasetRecord = datasets.getJsonObject(i);
+                                    String itemType = Util.getItemType(datasetRecord);
+
+                                    if (itemType.equals(VALIDATION_FAILURE_MSG)) {
+                                      datasetResult.handle(
+                                          Future.failedFuture(VALIDATION_FAILURE_MSG));
+                                      datasetResult.handle(
+                                          Future.failedFuture(VALIDATION_FAILURE_MSG));
+                                    }
+
+                                    if (ITEM_TYPE_RESOURCE_GROUP.equals(itemType)) {
+                                      String rgId = datasetRecord.getString(ID);
+                                      String providerId = datasetRecord.getString(PROVIDER);
+                                      int resourceItemCountInGroup =
+                                          resourceItemCount.containsKey(rgId)
+                                              ? resourceItemCount.getInteger(rgId)
+                                              : 0;
+                                      datasetRecord.put("totalResources", resourceItemCountInGroup);
+                                      datasetRecord.put(
+                                          "providerDescription", providerDetails.get(providerId));
+
+                                      JsonObject accessPolicy =
+                                          resourceAccessPolicy.containsKey(rgId)
+                                              ? resourceAccessPolicy.getJsonObject(rgId)
+                                              : new JsonObject()
+                                                  .put("PII", 0)
+                                                  .put("SECURE", 0)
+                                                  .put("OPEN", 0);
+                                      datasetRecord.put("accessPolicy", accessPolicy);
+
+                                      totalResourceItem += resourceItemCountInGroup;
+                                    }
+                                  }
+                                }
+                                JsonObject typeCount =
+                                    new JsonObject()
+                                        .put("totalDatasets", resourceGroupCount)
+                                        .put("totalResources", resourcesCount);
+                                typeCount.put("totalPublishers", providerCount);
+
+                                JsonObject jsonDataset =
+                                    new JsonObject()
+                                        .put("latestDataset", latestDatasets)
+                                        .put("typeCount", typeCount)
+                                        .put("featuredDataset", popularDatasets);
+                                datasetResult.complete(jsonDataset);
+                              }
+                            });
+                  } else {
+                    LOGGER.error("Fail: failed DB request");
+                    datasetResult.handle(Future.failedFuture(internalErrorResp));
+                  }
+                });
           } else {
             LOGGER.error("Fail: failed DB request");
             datasetResult.handle(Future.failedFuture(internalErrorResp));

--- a/src/main/java/iudx/catalogue/server/mlayer/MlayerServiceImpl.java
+++ b/src/main/java/iudx/catalogue/server/mlayer/MlayerServiceImpl.java
@@ -355,10 +355,19 @@ public class MlayerServiceImpl implements MlayerService {
         dbHandler -> {
           if (dbHandler.succeeded()) {
             JsonArray popularDataset = dbHandler.result().getJsonArray("results");
-            LOGGER.debug("popular datasets are {}", popularDataset);
+            JsonArray popularRgs = new JsonArray();
+            for (int popularRgCount = 0; popularRgCount < popularDataset.size(); popularRgCount++) {
+              String rgId =
+                  popularDataset.getJsonObject(popularRgCount).getString("resource_group");
+
+              if (rgId != null) {
+                popularRgs.add(rgId);
+              }
+            }
+            LOGGER.debug("popular resource group's id retrieved {}", popularRgs);
             databaseService.getMlayerPopularDatasets(
                 instance,
-                popularDataset,
+                popularRgs,
                 getPopularDatasetsHandler -> {
                   if (getPopularDatasetsHandler.succeeded()) {
                     LOGGER.info("Success: Getting data for the landing page.");

--- a/src/main/java/iudx/catalogue/server/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/util/Constants.java
@@ -151,6 +151,9 @@ public class Constants {
   public static final String TOTAL_RATINGS = "totalRatings";
   public static final String ICON_BASE64 = "icon_base64";
   public static final String PROVIDER_DES = "providerDescription";
+  public static final String RESOURCE_COUNT = "resourceCount";
+  public static final String PROVIDER_COUNT = "providerCount";
+  public static final String RESOURCE_GROUP_COUNT = "resourceGroupCount";
 
   /** HTTP Methods. */
   public static final String REQUEST_GET = "GET";
@@ -181,6 +184,8 @@ public class Constants {
   public static final int MAX_RESULT_WINDOW = 10000;
   public static final int MAXDISTANCE_LIMIT = 10000; // 10KM
   public static final int SERVICE_TIMEOUT = 3000;
+  public static final int POPULAR_DATASET_COUNT = 6;
+
 
 
   public static final String SUCCESS = "Success";

--- a/src/test/java/iudx/catalogue/server/database/DatabaseServiceImplTest.java
+++ b/src/test/java/iudx/catalogue/server/database/DatabaseServiceImplTest.java
@@ -287,7 +287,7 @@ public class DatabaseServiceImplTest {
         request,
         handler -> {
           if (handler.succeeded()) {
-            verify(client, times(24)).searchAsync(anyString(), any(), any());
+            verify(client, times(27)).searchAsync(anyString(), any(), any());
             vertxTestContext.completeNow();
           } else {
             vertxTestContext.failNow("Fail");
@@ -400,7 +400,7 @@ public class DatabaseServiceImplTest {
             handler -> {
               if (handler.failed()) {
                 databaseService.verifyInstance(instanceId);
-                verify(client, times(45)).searchAsync(any(), any(), any());
+                verify(client, times(48)).searchAsync(any(), any(), any());
                 assertEquals(TYPE_INTERNAL_SERVER_ERROR, handler.cause().getMessage());
                 vertxTestContext.completeNow();
               } else {
@@ -451,7 +451,7 @@ public class DatabaseServiceImplTest {
             boolHandler -> {
               if (boolHandler.succeeded()) {
                 assertEquals(json, asyncResult.result());
-                verify(client, times(27)).searchAsync(anyString(), any(), any());
+                verify(client, times(30)).searchAsync(anyString(), any(), any());
                 vertxTestContext.completeNow();
               } else {
                 vertxTestContext.failNow("Fail");
@@ -607,7 +607,7 @@ public class DatabaseServiceImplTest {
         json,
         handler -> {
           if (handler.failed()) {
-            verify(client, times(48)).searchAsync(any(), any(), any());
+            verify(client, times(51)).searchAsync(any(), any(), any());
             vertxTestContext.completeNow();
           } else vertxTestContext.failNow("Fail");
         });
@@ -639,7 +639,7 @@ public class DatabaseServiceImplTest {
         json,
         handler -> {
           if (handler.succeeded()) {
-            verify(client, times(71)).searchAsync(any(), any(), any());
+            verify(client, times(74)).searchAsync(any(), any(), any());
             vertxTestContext.completeNow();
           } else {
             vertxTestContext.failNow("Fail");
@@ -688,7 +688,7 @@ public class DatabaseServiceImplTest {
         json,
         handler -> {
           if (handler.failed()) {
-            verify(client, times(69)).searchAsync(any(), any(), any());
+            verify(client, times(72)).searchAsync(any(), any(), any());
             vertxTestContext.completeNow();
           } else {
             vertxTestContext.failNow("Fail");
@@ -814,7 +814,7 @@ public class DatabaseServiceImplTest {
         json,
         handler -> {
           if (handler.failed()) {
-            verify(client, times(58)).searchAsync(any(), any(), any());
+            verify(client, times(61)).searchAsync(any(), any(), any());
             vertxTestContext.completeNow();
           } else {
             vertxTestContext.failNow("Fail");
@@ -888,7 +888,7 @@ public class DatabaseServiceImplTest {
         json,
         handler -> {
           if (handler.succeeded()) {
-            verify(client, times(50)).searchAsync(any(), any(), any());
+            verify(client, times(53)).searchAsync(any(), any(), any());
             vertxTestContext.completeNow();
 
           } else {
@@ -1040,7 +1040,7 @@ public class DatabaseServiceImplTest {
         json,
         handler -> {
           if (handler.succeeded()) {
-            verify(client, times(23)).searchAsync(any(), any(), any());
+            verify(client, times(26)).searchAsync(any(), any(), any());
 
             vertxTestContext.completeNow();
           } else {
@@ -1106,7 +1106,7 @@ public class DatabaseServiceImplTest {
         json,
         handler -> {
           if (handler.succeeded()) {
-            verify(client, times(67)).searchAsync(any(), any(), any());
+            verify(client, times(70)).searchAsync(any(), any(), any());
             vertxTestContext.completeNow();
 
           } else {
@@ -1142,7 +1142,7 @@ public class DatabaseServiceImplTest {
         json,
         handler -> {
           if (handler.succeeded()) {
-            verify(client, times(34)).searchAsync(any(), any(), any());
+            verify(client, times(37)).searchAsync(any(), any(), any());
             vertxTestContext.completeNow();
 
           } else {
@@ -1290,7 +1290,7 @@ public class DatabaseServiceImplTest {
         .onComplete(
             handler -> {
               if (handler.failed()) {
-                verify(client, times(43)).searchAsync(any(), any(), any());
+                verify(client, times(46)).searchAsync(any(), any(), any());
                 verify(nlpService, times(0)).getEmbedding(any(), any());
                 verify(geoService, times(0)).geoSummarize(any(), any());
                 vertxTestContext.completeNow();
@@ -1318,7 +1318,7 @@ public class DatabaseServiceImplTest {
         json,
         handler -> {
           if (handler.failed()) {
-            verify(client, times(63)).searchAsync(any(), any(), any());
+            verify(client, times(66)).searchAsync(any(), any(), any());
             testContext.completeNow();
           } else {
             testContext.failNow("fail");
@@ -1350,7 +1350,7 @@ public class DatabaseServiceImplTest {
         json,
         handler -> {
           if (handler.succeeded()) {
-            verify(client, times(30)).searchAsync(any(), any(), any());
+            verify(client, times(33)).searchAsync(any(), any(), any());
             verify(client, times(4)).docPostAsync(any(), any(), any());
             testContext.completeNow();
           } else {
@@ -1371,7 +1371,7 @@ public class DatabaseServiceImplTest {
         json,
         handler -> {
           if (handler.failed()) {
-            verify(client, times(60)).searchAsync(any(), any(), any());
+            verify(client, times(63)).searchAsync(any(), any(), any());
             testContext.completeNow();
 
           } else {
@@ -1403,7 +1403,7 @@ public class DatabaseServiceImplTest {
         handler -> {
           if (handler.failed()) {
             verify(client, times(5)).docPostAsync(any(), any(), any());
-            verify(client, times(53)).searchAsync(any(), any(), any());
+            verify(client, times(56)).searchAsync(any(), any(), any());
 
             testContext.completeNow();
 
@@ -1441,7 +1441,7 @@ public class DatabaseServiceImplTest {
         requestParams,
         handler -> {
           if (handler.succeeded()) {
-            verify(client, times(35)).searchAsync(any(), any(), any());
+            verify(client, times(38)).searchAsync(any(), any(), any());
             testContext.completeNow();
           } else {
             testContext.failNow("Fail");
@@ -1459,7 +1459,7 @@ public class DatabaseServiceImplTest {
         requestParams,
         handler -> {
           if (handler.failed()) {
-            verify(client, times(61)).searchAsync(any(), any(), any());
+            verify(client, times(64)).searchAsync(any(), any(), any());
             testContext.completeNow();
 
           } else {
@@ -1822,7 +1822,7 @@ public class DatabaseServiceImplTest {
         handler -> {
           if (handler.failed()) {
 
-            verify(client, times(68)).searchAsync(any(), any(), any());
+            verify(client, times(71)).searchAsync(any(), any(), any());
 
             testContext.completeNow();
 
@@ -1867,7 +1867,7 @@ public class DatabaseServiceImplTest {
         requestParams,
         handler -> {
           if (handler.succeeded()) {
-            verify(client, times(38)).searchAsync(any(), any(), any());
+            verify(client, times(41)).searchAsync(any(), any(), any());
             testContext.completeNow();
           } else {
             testContext.failNow("Fail");
@@ -1886,7 +1886,7 @@ public class DatabaseServiceImplTest {
         requestParams,
         handler -> {
           if (handler.failed()) {
-            verify(client, times(56)).searchAsync(any(), any(), any());
+            verify(client, times(59)).searchAsync(any(), any(), any());
             testContext.completeNow();
 
           } else {
@@ -2180,7 +2180,7 @@ public class DatabaseServiceImplTest {
         requestParams,
         handler -> {
           if (handler.succeeded()) {
-            verify(client, times(25)).searchAsync(any(), any(), any());
+            verify(client, times(28)).searchAsync(any(), any(), any());
             testContext.completeNow();
           } else {
             testContext.failNow("Fail");
@@ -2199,7 +2199,7 @@ public class DatabaseServiceImplTest {
         requestParams,
         handler -> {
           if (handler.failed()) {
-            verify(client, times(46)).searchAsync(any(), any(), any());
+            verify(client, times(49)).searchAsync(any(), any(), any());
             testContext.completeNow();
 
           } else {
@@ -2294,7 +2294,7 @@ public class DatabaseServiceImplTest {
         request,
         handler -> {
           if (handler.succeeded()) {
-            verify(client, times(52)).searchAsync(any(), any(), any());
+            verify(client, times(55)).searchAsync(any(), any(), any());
             verify(client, times(2)).searchAsyncDataset(any(), any(), any());
 
             testContext.completeNow();
@@ -2340,7 +2340,7 @@ public class DatabaseServiceImplTest {
             testContext.failNow("fail");
 
           } else {
-            verify(client, times(64)).searchAsync(any(), any(), any());
+            verify(client, times(67)).searchAsync(any(), any(), any());
             verify(client, times(2)).searchAsyncDataset(any(), any(), any());
 
             testContext.completeNow();
@@ -2546,7 +2546,7 @@ public class DatabaseServiceImplTest {
         handler -> {
           if (handler.failed()) {
             // verify(client, times(1)).searchAsyncDataset(any(), any(), any());
-            verify(client, times(29)).searchAsync(any(), any(), any());
+            verify(client, times(32)).searchAsync(any(), any(), any());
 
             testContext.completeNow();
 
@@ -2625,15 +2625,98 @@ public class DatabaseServiceImplTest {
         highestCountResource,
         handler -> {
           if (handler.succeeded()) {
-            verify(client, times(55)).searchAsync(any(), any(), any());
-            verify(client, times(5)).searchAsyncResourceGroupAndProvider(any(), any(), any());
-            verify(client, times(5)).resourceAggregationAsync(any(), any(), any());
+            verify(client, times(58)).searchAsync(any(), any(), any());
+            verify(client, times(4)).searchAsyncResourceGroupAndProvider(any(), any(), any());
+            verify(client, times(6)).resourceAggregationAsync(any(), any(), any());
             testContext.completeNow();
           } else {
             testContext.failNow("fail");
           }
         });
   }
+
+    @Test
+    @Description("test getMlayerPopularDatasets method when DB Request is successful")
+    public void testGetMlayerPopularDatasetsSuccess2(VertxTestContext testContext) {
+      String instanceName = "";
+        DatabaseServiceImpl databaseService =
+                new DatabaseServiceImpl(
+                        webClient,
+                        client,
+                        docIndex,
+                        ratingIndex,
+                        mlayerInstanceIndex,
+                        mlayerDomainIndex,
+                        nlpService,
+                        geoService);
+        JsonArray accessPolicy = new JsonArray();
+        JsonObject accessPolicyJson =
+                new JsonObject()
+                        .put("resourcegroup", "abcd/abcd/abcd/abcd")
+                        .put("instance", "instance")
+                        .put(BUCKETS, accessPolicy)
+                        .put("resourceGroup", "abc");
+        JsonObject json2 =
+                new JsonObject()
+                        .put("resourcegroup", "abcd/abcd/abcd/abcd")
+                        .put("instance", "instance")
+                        .put(BUCKETS, accessPolicy)
+                        .put("resourceGroup", "abc");
+
+        JsonArray highestCountResource = new JsonArray().add(accessPolicyJson).add(json2);
+
+        JsonArray resourceArray = new JsonArray();
+        JsonArray typeArray = new JsonArray().add(0, "iudx:ResourceGroup");
+
+        JsonObject instance =
+                new JsonObject()
+                        .put("name", "agra")
+                        .put("icon", "path_of_agra-icon.jpg")
+                        .put(TYPE, typeArray)
+                        .put("itemCreatedAt", "2022-12-15T04:23:28+0530")
+                        .put("id", "abcd/abcd/abcd/abcd")
+                        .put("rgid", "abcd/abcd/abcd/abcd")
+                        .put("instance", "instance")
+                        .put("itemCreatedAt", "2023-08-30T05:09:54+0530")
+                        .put(KEY, "719390c5-30c0-4339-b0f2-1be292312104")
+                        .put("doc_count", 2)
+                        .put(KEY, accessPolicyJson)
+                        .put("access_policies", accessPolicyJson)
+                        .put("resourceGroupAndProvider", resourceArray)
+                        .put("providerCount", 7);
+        resourceArray.add(instance).add(instance).add(instance).add(instance).add(instance);
+        JsonArray latestDataset = new JsonArray().add(accessPolicyJson);
+        JsonArray resultArray =
+                new JsonArray().add(instance).add(instance).add(instance).add(instance).add(instance).add(instance);
+
+    JsonObject aggResult = new JsonObject().put("resourceGroupCount", 1).put("resourceCount", 1).put("providerCount", 1);
+
+    JsonObject result =
+        new JsonObject()
+            .put(TOTAL_HITS, 1)
+            .put(RESULTS, resultArray)
+            .put("latestDataset", latestDataset)
+            .put("count", aggResult);
+        when(asyncResult.result()).thenReturn(result);
+        when(asyncResult.succeeded()).thenReturn(true);
+        mockAsyncMethod(client -> client.searchAsync(any(), any(), any()));
+        mockAsyncMethod(client -> client.resourceAggregationAsync(any(), any(), any()));
+      //  mockAsyncMethod(client -> client.searchAsyncResourceGroupAndProvider(any(), any(), any()));
+        mockAsyncMethod(client-> client.searchLatestResource(any(),any(),any()));
+        databaseService.getMlayerPopularDatasets(
+                instanceName,
+                highestCountResource,
+                handler -> {
+                    if (handler.succeeded()) {
+                        verify(client, times(23)).searchAsync(any(), any(), any());
+                   //     verify(client, times(4)).searchAsyncResourceGroupAndProvider(any(), any(), any());
+                        verify(client, times(3)).resourceAggregationAsync(any(), any(), any());
+                        testContext.completeNow();
+                    } else {
+                        testContext.failNow("fail");
+                    }
+                });
+    }
 
   @Test
   @Description("test getMlayerPopularDatasets method when DB Request fails")
@@ -2673,7 +2756,7 @@ public class DatabaseServiceImplTest {
   @Description(
       "test getMlayerPopularDatasets method when DB Request is successful and type equals iudx:Provider")
   public void testGetMlayerPopularDatasetsProviderSuccess(VertxTestContext testContext) {
-    String instanceName = "";
+    String instanceName = "pune";
     DatabaseServiceImpl databaseService =
         new DatabaseServiceImpl(
             webClient,
@@ -2692,7 +2775,7 @@ public class DatabaseServiceImplTest {
             .put(BUCKETS, accessPolicy);
     JsonObject json2 = new JsonObject().put("rgid", "duumy-id");
 
-    JsonArray highestCountResource = new JsonArray().add(record).add(json2);
+    JsonArray highestCountResource = new JsonArray().add("abc").add("def");
 
     JsonArray resourceArray = new JsonArray();
     JsonArray typeArray = new JsonArray().add(0, "iudx:Provider");
@@ -2752,10 +2835,10 @@ public class DatabaseServiceImplTest {
         highestCountResource,
         handler -> {
           if (handler.succeeded()) {
-            verify(DatabaseServiceImpl.client, times(40)).searchAsync(any(), any(), any());
-            verify(DatabaseServiceImpl.client, times(3))
+            verify(DatabaseServiceImpl.client, times(43)).searchAsync(any(), any(), any());
+            verify(DatabaseServiceImpl.client, times(2))
                 .searchAsyncResourceGroupAndProvider(any(), any(), any());
-            verify(DatabaseServiceImpl.client, times(4))
+            verify(DatabaseServiceImpl.client, times(5))
                 .resourceAggregationAsync(any(), any(), any());
             testContext.completeNow();
           } else {
@@ -2817,7 +2900,7 @@ public class DatabaseServiceImplTest {
         request,
         handler -> {
           if (handler.succeeded()) {
-            verify(client, times(21)).searchAsync(any(), any(), any());
+            verify(client, times(24)).searchAsync(any(), any(), any());
             vertxTestContext.completeNow();
 
           } else {
@@ -2906,7 +2989,7 @@ public class DatabaseServiceImplTest {
         handler -> {
           if (handler.succeeded()) {
             //   verify(client, times(6)).searchAsync(any(), any(), any());
-            verify(client, times(2)).searchAsyncResourceGroupAndProvider(any(), any(), any());
+            verify(client, times(1)).searchAsyncResourceGroupAndProvider(any(), any(), any());
             testContext.completeNow();
 
           } else {

--- a/src/test/java/iudx/catalogue/server/mlayer/MlayerServiceTest.java
+++ b/src/test/java/iudx/catalogue/server/mlayer/MlayerServiceTest.java
@@ -931,7 +931,8 @@ public class MlayerServiceTest {
     JsonArray jsonArray = new JsonArray();
     JsonObject json = new JsonObject();
     json.put("results", jsonArray);
-    jsonArray.add("dataset");
+    json.put("resource_grpup", "abc");
+    jsonArray.add(json);
     String instanceName = "dummy";
     when(asyncResult.result()).thenReturn(json);
 


### PR DESCRIPTION
Changes made in popularDataset API to reduce the response item.
The new changes include retrieving six newly formed resource groups along with resource item count, resource group count and provider count. Extra elastic call is being made to get six frequently used resource group and all providers. The providers are fetched to get the description which is added to the resource group items. Another call to elastic is made to fetch the resource count of the twelve resource groups and access policy count of each resource. 