### PR TITLE
ITs Fix: Update 'resourceServerRegURL' field in ResourceServerItem payload for PUT API in 5.5.0 branch

### DIFF
--- a/src/test/java/iudx/catalogue/server/apiserver/integrationtests/crudApisIT/CrudAPIsIT.java
+++ b/src/test/java/iudx/catalogue/server/apiserver/integrationtests/crudApisIT/CrudAPIsIT.java
@@ -536,7 +536,7 @@ public class CrudAPIsIT {
     @Test
     @Order(13)
     @DisplayName("testing update DX Resource Server Item - 200")
-    void updateDXResourceItem(){
+    void updateDXResourceServerItem(){
         JsonObject jsonPayload = new JsonObject()
                 .put("@context", "https://voc.iudx.org.in/")
                 .put("type", new JsonArray().add("iudx:ResourceServer"))
@@ -558,7 +558,7 @@ public class CrudAPIsIT {
                                 )
                         )
                 )
-                .put("resourceServerRegURL", "rs.iudx.io")
+                .put("resourceServerRegURL", "rs-test-pm.iudx.io")
                 .put("resourceAccessModalities", new JsonArray()
                         .add(new JsonObject()
                                 .put("type", new JsonArray().add("iudx:HTTPAccess"))


### PR DESCRIPTION
This PR resolves an issue where the aud field in the JWT token and the resourceServerRegURL field in the ResourceServerItem payload were inconsistent, resulting in a 401 Unauthorized error.

**Changes:**
- The resourceServerRegURL field in the ResourceServerItem payload was updated to reflect the correct value of "rs-test-pm.iudx.io", aligning it with the updated aud field in the JWT token.
- The mismatch between the aud field and resourceServerRegURL in the payload was causing authorization failures of PUT API, which is now fixed.