### PR TITLE
Remove constraints from attribute/term search schema for values field

### DIFF
--- a/src/main/resources/iudx/catalogue/server/validator/attributeSearchQuerySchema.json
+++ b/src/main/resources/iudx/catalogue/server/validator/attributeSearchQuerySchema.json
@@ -8,11 +8,8 @@
     "searchType": { "const": "term" },
     "values": {
       "type": "array",
-      "minItems": 1,
-      "maxItems": 20,
       "items": {
-        "type": "string",
-        "pattern": "^[a-zA-Z0-9]([\\w\\-.,:/()& ]*[a-zA-Z0-9])?$"
+        "type": "string"
       }
     }
   },


### PR DESCRIPTION
- Removed regex pattern, minItems, and maxItems constraints from the values array in the term search type schema used for validating /search request payloads.

- Motivation: Some use cases (e.g., sending long or unconstrained tag lists) were failing schema validation unnecessarily.

- This makes the term search more flexible and avoids client-side rejections for valid business queries.