### PR TITLE
Add support for filtering by uploadedBy in list API

### DIFF
--- a/src/main/java/iudx/catalogue/server/apiserver/ListApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/ListApis.java
@@ -99,6 +99,7 @@ public final class ListApis {
           case DEPARTMENT:
           case ORGANIZATION_TYPE:
           case FILE_FORMAT:
+          case UPLOADED_BY:
             type = itemType;
             break;
           case OWNER:
@@ -269,6 +270,7 @@ public final class ListApis {
           case FILE_FORMAT:
           case DATA_READINESS:
           case MODEL_TYPE:
+          case UPLOADED_BY:
           case ID:
             type.add(itemType);
             break;

--- a/src/main/java/iudx/catalogue/server/database/QueryDecoder.java
+++ b/src/main/java/iudx/catalogue/server/database/QueryDecoder.java
@@ -697,7 +697,8 @@ public final class QueryDecoder {
 
     if (itemType.equalsIgnoreCase(TAGS) || itemType.equalsIgnoreCase(DEPARTMENT)
         || itemType.equalsIgnoreCase(ORGANIZATION_TYPE) || itemType.equalsIgnoreCase(FILE_FORMAT)
-        || itemType.equalsIgnoreCase(DATA_READINESS) || itemType.equalsIgnoreCase(MODEL_TYPE)) {
+        || itemType.equalsIgnoreCase(DATA_READINESS) || itemType.equalsIgnoreCase(MODEL_TYPE)
+        || itemType.equalsIgnoreCase(UPLOADED_BY)) {
       if (instanceId == null || instanceId == "") {
         tempQuery = LIST_AGGREGATION_QUERY_NO_FILTER
             .replace("$field", itemType + KEYWORD_KEY);

--- a/src/main/java/iudx/catalogue/server/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/util/Constants.java
@@ -180,6 +180,7 @@ public class Constants {
   public static final String ORGANIZATION_TYPE = "organizationType";
   public static final String ORGANIZATION_ID = "organizationId";
   public static final String FILE_FORMAT = "fileFormat";
+  public static final String UPLOADED_BY = "uploadedBy";
   public static final String DATA_READINESS = "dataReadiness";
   public static final String MODEL_TYPE = "modelType";
   public static final String AVERAGE_RATING = "average_rating";


### PR DESCRIPTION
### Summary

This PR introduces support for using `uploadedBy` as a valid filter in the `/list` API. This allows users to filter items based on the organization or user who uploaded the resource.
