### PR TITLE
Change access denied message for private items

### DIFF
--- a/src/main/java/iudx/catalogue/server/apiserver/CrudApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/CrudApis.java
@@ -441,7 +441,7 @@ public final class CrudApis {
           response.setStatusCode(403).end(new RespBuilder()
               .withType(TYPE_ACCESS_DENIED)
               .withTitle("Token is not provided")
-              .withDetail("Token required for private items")
+              .withDetail("You don't have access to the resource.")
               .getResponse());
           return;
         }


### PR DESCRIPTION
- Updated the error message shown when a token is not provided for accessing private items.
- Previous message: `"Token required for private items"`
- Updated to: `"You don't have access to the resource."`