### PR TITLE
Add /health/live Endpoint for Liveness check

### DIFF
--- a/src/main/java/iudx/catalogue/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/ApiServerVerticle.java
@@ -34,6 +34,7 @@ import org.apache.logging.log4j.Logger;
  * <p>The API Server verticle implements the IUDX Catalogue Server APIs. It handles the API requests
  * from the clients and interacts with the associated Service to respond.
  *
+ * @version 1.0
  * @see io.vertx.core.Vertx
  * @see io.vertx.core.AbstractVerticle
  * @see io.vertx.core.http.HttpServer
@@ -41,7 +42,6 @@ import org.apache.logging.log4j.Logger;
  * @see io.vertx.servicediscovery.ServiceDiscovery
  * @see io.vertx.servicediscovery.types.EventBusService
  * @see io.vertx.spi.cluster.hazelcast.HazelcastClusterManager
- * @version 1.0
  * @since 2020-05-31
  */
 public class ApiServerVerticle extends AbstractVerticle {
@@ -410,6 +410,13 @@ public class ApiServerVerticle extends AbstractVerticle {
               }
             });
 
+    router.get(api.getRouteHealthLive()).handler(ctx ->
+        ctx.response()
+            .setStatusCode(200)
+            .putHeader("Content-Type", "text/plain")
+            .end("Alive")
+    );
+
     /* NLP Search */
     router
         .get(api.getRouteNlpSearch())
@@ -526,10 +533,10 @@ public class ApiServerVerticle extends AbstractVerticle {
               } else {
                 if (routingContext.request().headers().contains(HEADER_AUTHORIZATION)) {
                   String authHeader = routingContext.request().getHeader(HEADER_AUTHORIZATION);
-                if (authHeader != null && authHeader.startsWith("Bearer ")) {
-                  String token = authHeader.substring("Bearer ".length()).trim();
-                  routingContext.put(HEADER_TOKEN, token);
-                }
+                  if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                    String token = authHeader.substring("Bearer ".length()).trim();
+                    routingContext.put(HEADER_TOKEN, token);
+                  }
                   ratingApis.getRatingHandler(routingContext);
                 } else {
                   LOGGER.error("Unauthorized Operation");
@@ -799,7 +806,7 @@ public class ApiServerVerticle extends AbstractVerticle {
         .route(api.getStackRestApis() + "/*")
         .subRouter(
             new StacRestApi(
-                     router, api, config(), validationService, authService, auditingService)
+                router, api, config(), validationService, authService, auditingService)
                 .init());
 
     // Start server

--- a/src/main/java/iudx/catalogue/server/apiserver/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/util/Constants.java
@@ -64,6 +64,7 @@ public class Constants {
 
   public static final String ROUTE_RELATIONSHIP = "/relationship";
   public static final String ROUTE_SEARCH = "/search";
+  public static final String ROUTE_HEALTH_LIVE = "/health/live";
   public static final String ROUTE_SEARCH_MY_ASSETS = "/search/myassets";
   public static final String ROUTE_NLP_SEARCH = "/nlpsearch";
   public static final String ROUTE_LIST_ITEMS = "/list/:itemType";

--- a/src/main/java/iudx/catalogue/server/util/Api.java
+++ b/src/main/java/iudx/catalogue/server/util/Api.java
@@ -16,6 +16,7 @@ public class Api {
   private StringBuilder routeInstance;
   private StringBuilder routeRelationship;
   private StringBuilder routeSearch;
+  private StringBuilder routeHealthLive;
   private StringBuilder routeSearchMyAssets;
   private StringBuilder routeNlpSearch;
   private StringBuilder routeListItems;
@@ -67,6 +68,7 @@ public class Api {
     routeInstance = new StringBuilder(dxApiBasePath).append(ROUTE_INSTANCE);
     routeRelationship = new StringBuilder(dxApiBasePath).append(ROUTE_RELATIONSHIP);
     routeSearch = new StringBuilder(dxApiBasePath).append(ROUTE_SEARCH);
+    routeHealthLive = new StringBuilder(dxApiBasePath).append(ROUTE_HEALTH_LIVE);
     routeSearchMyAssets = new StringBuilder(dxApiBasePath).append(ROUTE_SEARCH_MY_ASSETS);
     routeNlpSearch = new StringBuilder(dxApiBasePath).append(ROUTE_NLP_SEARCH);
     routeListItems = new StringBuilder(dxApiBasePath).append(ROUTE_LIST_ITEMS);
@@ -114,6 +116,11 @@ public class Api {
   public String getRouteSearch() {
     return routeSearch.toString();
   }
+
+  public String getRouteHealthLive() {
+    return routeHealthLive.toString();
+  }
+
   public String getRouteSearchMyAssets() {
     return routeSearchMyAssets.toString();
   }


### PR DESCRIPTION
### Summary

This PR introduces the `/health/live` endpoint to serve as a liveness probe for the Catalogue service. It helps orchestrators like Kubernetes determine whether the application process is running and able to respond to HTTP requests.

### Details

- Adds a simple `/health/live` route that returns `200 OK` with response body `"Alive"`.
- Does not perform any service or dependency checks.
- Intended to be used by container platforms for monitoring app liveness.

This endpoint is purely for runtime verification and should always return success unless the application has crashed or failed to bind the HTTP port.
