### PR TITLE
feat(filters): include SECURE datasets and resourceServerRegURL in /list API filters

### DIFF
--- a/src/main/java/iudx/catalogue/server/apiserver/ListApis.java
+++ b/src/main/java/iudx/catalogue/server/apiserver/ListApis.java
@@ -279,6 +279,7 @@ public final class ListApis {
           case NAME:
           case ACCESS_POLICY:
           case RESOURCE_SERVER_NAME:
+          case RESOURCE_SERVER_REG_URL:
             type.add(itemType);
             break;
           case OWNER:

--- a/src/main/java/iudx/catalogue/server/database/Constants.java
+++ b/src/main/java/iudx/catalogue/server/database/Constants.java
@@ -39,6 +39,7 @@ public class Constants {
   public static final String OPEN = "OPEN";
 
   public static final String RESTRICTED = "RESTRICTED";
+  public static final String SECURE = "SECURE";
   public static final String PRIVATE = "PRIVATE";
 
   /** ElasticClient search types. */

--- a/src/main/java/iudx/catalogue/server/database/QueryDecoder.java
+++ b/src/main/java/iudx/catalogue/server/database/QueryDecoder.java
@@ -961,7 +961,7 @@ public final class QueryDecoder {
     queryBuilder.append("\"query\": { \"bool\": {");
     // Access policy filter
     JsonArray allowedPolicies = new JsonArray();
-    allowedPolicies.add(OPEN).add(RESTRICTED);
+    allowedPolicies.add(OPEN).add(RESTRICTED).add(SECURE);
 
     // Start "filter" array
     queryBuilder.append("\"filter\": [");

--- a/src/main/java/iudx/catalogue/server/util/Constants.java
+++ b/src/main/java/iudx/catalogue/server/util/Constants.java
@@ -185,6 +185,7 @@ public class Constants {
   public static final String DEPARTMENT = "department";
   public static final String ORGANIZATION_TYPE = "organizationType";
   public static final String RESOURCE_SERVER_NAME = "resourceServerName";
+  public static final String RESOURCE_SERVER_REG_URL = "resourceServerRegURL";
   public static final String ORGANIZATION_ID = "organizationId";
   public static final String ORGANIZATION_NAME = "organizationName";
   public static final String FILE_FORMAT = "fileFormat";


### PR DESCRIPTION
- Updated filter-building logic to include `SECURE` datasets alongside `OPEN`, `RESTRICTED`, and user-owned `PRIVATE` datasets when authorized.
- Added `resourceServerRegURL` as part of the available filters in the `/list` API response.